### PR TITLE
Disable TestDescriptor via "Disabled" property

### DIFF
--- a/pkg/jobmanager/job.go
+++ b/pkg/jobmanager/job.go
@@ -73,6 +73,9 @@ func newJob(ctx xcontext.Context, registry *pluginregistry.PluginRegistry, jobDe
 		if err := limits.NewValidator().ValidateTestName(testName); err != nil {
 			return nil, err
 		}
+		if td.Disabled {
+			continue
+		}
 		test := test.Test{
 			Name:                testName,
 			TargetManagerBundle: bundleTargetManager,

--- a/pkg/jobmanager/job_test.go
+++ b/pkg/jobmanager/job_test.go
@@ -1,0 +1,91 @@
+package jobmanager
+
+import (
+	"testing"
+
+	"github.com/linuxboot/contest/pkg/job"
+	"github.com/linuxboot/contest/pkg/pluginregistry"
+	"github.com/linuxboot/contest/pkg/test"
+	"github.com/linuxboot/contest/pkg/xcontext"
+	"github.com/linuxboot/contest/plugins/reporters/noop"
+	"github.com/linuxboot/contest/plugins/targetmanagers/targetlist"
+	"github.com/linuxboot/contest/plugins/testfetchers/literal"
+	"github.com/linuxboot/contest/plugins/teststeps/echo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisabledTestDescriptor(t *testing.T) {
+	pr := pluginregistry.NewPluginRegistry(xcontext.Background())
+	require.NoError(t, pr.RegisterTestStep(echo.Load()))
+	require.NoError(t, pr.RegisterTargetManager(targetlist.Load()))
+	require.NoError(t, pr.RegisterTestFetcher(literal.Load()))
+	require.NoError(t, pr.RegisterReporter(noop.Load()))
+
+	testFetcherParams1 := `{
+	    "TestName": "TestDisabled",
+		"Steps": [
+			{
+				"name": "echo",
+				"label": "echo text",
+				"parameters": {
+					"text": ["Some text1"]
+				}
+			}
+		]
+	}`
+	testFetcherParams2 := `{
+	    "TestName": "TestEnabled",
+		"Steps": [
+			{
+				"name": "echo",
+				"label": "echo text",
+				"parameters": {
+					"text": ["Some text1"]
+				}
+			}
+		]
+	}`
+
+	targetManagerAcquireParameters := `{
+		"Targets": [
+			{
+				"ID": "id1",
+				"FQDN": "some-host.fna1.dummy-facebook.com"
+			}
+		]
+	}`
+
+	testDescriptors := []*test.TestDescriptor{
+		{
+			Disabled:                       true,
+			TargetManagerName:              "targetList",
+			TargetManagerAcquireParameters: []byte(targetManagerAcquireParameters),
+			TargetManagerReleaseParameters: []byte("{}"),
+			TestFetcherName:                "literal",
+			TestFetcherFetchParameters:     []byte(testFetcherParams1),
+		},
+		{
+			TargetManagerName:              "targetList",
+			TargetManagerAcquireParameters: []byte(targetManagerAcquireParameters),
+			TargetManagerReleaseParameters: []byte("{}"),
+			TestFetcherName:                "literal",
+			TestFetcherFetchParameters:     []byte(testFetcherParams2),
+		},
+	}
+	jd := job.Descriptor{
+		TestDescriptors: testDescriptors,
+		JobName:         "Test",
+		Reporting: job.Reporting{
+			RunReporters: []job.ReporterConfig{
+				{Name: "noop"},
+			},
+		},
+	}
+
+	result, err := NewJobFromDescriptor(xcontext.Background(), pr, &jd)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.Len(t, result.Tests, 1)
+	require.Equal(t, result.Tests[0].Name, "TestEnabled")
+}

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -24,6 +24,9 @@ type Test struct {
 // job creation request. The test descriptors are part of the main JobDescriptor
 // JSON document.
 type TestDescriptor struct {
+	// Disabled allows to disable the test
+	Disabled bool
+
 	// TargetManager-related parameters
 	TargetManagerName              string
 	TargetManagerAcquireParameters json.RawMessage


### PR DESCRIPTION
All testing frameworks have an ability to disable tests.
For that purpose, a TestDescriptor.Disabled field was added