### PR TITLE
server/jobmanager: Reject jobs with zero tests or zero steps in a test

### DIFF
--- a/pkg/jobmanager/bundles.go
+++ b/pkg/jobmanager/bundles.go
@@ -75,6 +75,10 @@ func newBundlesFromSteps(ctx xcontext.Context, descriptors []*test.TestStepDescr
 		stepBundles = append(stepBundles, *tsb)
 	}
 
+	if len(stepBundles) == 0 {
+		return nil, fmt.Errorf("at least one test step is required per test")
+	}
+
 	return stepBundles, nil
 
 }

--- a/pkg/jobmanager/job.go
+++ b/pkg/jobmanager/job.go
@@ -35,6 +35,9 @@ func newJob(ctx xcontext.Context, registry *pluginregistry.PluginRegistry, jobDe
 	if err := jobDescriptor.Validate(); err != nil {
 		return nil, fmt.Errorf("could not validate job descriptor: %w", err)
 	}
+	if len(jobDescriptor.TestDescriptors) == 0 {
+		return nil, fmt.Errorf("cannot create job with zero tests")
+	}
 
 	runReportersBundle, finalReportersBundle, err := newReportingBundles(registry, jobDescriptor)
 	if err != nil {

--- a/pkg/storage/limits/limits_test.go
+++ b/pkg/storage/limits/limits_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/linuxboot/contest/plugins/reporters/noop"
 	"github.com/linuxboot/contest/plugins/targetmanagers/targetlist"
 	"github.com/linuxboot/contest/plugins/testfetchers/literal"
+	"github.com/linuxboot/contest/plugins/teststeps/echo"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -91,9 +92,18 @@ func TestTestName(t *testing.T) {
 	require.NoError(t, err)
 	err = pluginRegistry.RegisterReporter(noop.Load())
 	require.NoError(t, err)
+	err = pluginRegistry.RegisterTestStep(echo.Load())
+	require.NoError(t, err)
 
 	testFetchParams, err := json.Marshal(&literal.FetchParameters{
 		TestName: strings.Repeat("A", limits.MaxTestNameLen+1),
+		Steps: []*test.TestStepDescriptor{{
+			Label: "abc",
+			Name:  "echo",
+			Parameters: test.TestStepParameters{
+				"text": []test.Param{*test.NewParam("\"abc\"")},
+			},
+		}},
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Fixes #29.

It is a tiny bit more complicated than in the ticket: Jobs can either have zero _tests_ or they have tests, but at least one of them contains zero _test steps_. I am rejecting both cases here for consistency.

Signed-off-by: Tobias Fleig <tfleig@fb.com>