### PR TITLE
Fea/exec exit code map

### DIFF
--- a/cmds/exec_agent/sync.go
+++ b/cmds/exec_agent/sync.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"sync"
 )
 
@@ -67,4 +68,9 @@ func (sb *SafeBuffer) Len() int {
 	defer sb.mu.Unlock()
 
 	return sb.b.Len()
+}
+
+type LenReader interface {
+	io.Reader
+	Len() int
 }

--- a/cmds/exec_agent/sync.go
+++ b/cmds/exec_agent/sync.go
@@ -74,3 +74,25 @@ type LenReader interface {
 	io.Reader
 	Len() int
 }
+
+// SafeExitCode is a sync storage for the exit code of a process
+// the initial value of nil cannot be reset after the first set
+type SafeExitCode struct {
+	exitCode *int
+
+	mu sync.Mutex
+}
+
+func (s *SafeExitCode) Store(code int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.exitCode = &code
+}
+
+func (s *SafeExitCode) Load() *int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.exitCode
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
-	github.com/aws/aws-sdk-go v1.41.13
+	github.com/aws/aws-sdk-go v1.41.14
 	github.com/benbjohnson/clock v1.1.0
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chappjc/logrus-prefix v0.0.0-20180227015900-3a1d64819adb
@@ -42,7 +42,7 @@ require (
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.19.1
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
-	golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 // indirect
+	golang.org/x/sys v0.0.0-20211031064116-611d5d643895 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/aws/aws-sdk-go v1.27.0 h1:0xphMHGMLBrPMfxR2AmVjZKcMEESEgWF8Kru94BNByk
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.41.13 h1:wGgr6jkHdGExF33phfOqijFq7ZF+h7a6FXvJc77GpTc=
 github.com/aws/aws-sdk-go v1.41.13/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aws/aws-sdk-go v1.41.14 h1:zJnJ8Y964DjyRE55UVoMKgOG4w5i88LpN6xSpBX7z84=
+github.com/aws/aws-sdk-go v1.41.14/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -418,6 +420,7 @@ github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -642,6 +645,8 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6DgObAVZV+Fsp050NqXik=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211031064116-611d5d643895 h1:iaNpwpnrgL5jzWS0vCNnfa8HqzxveCFpFx3uC/X4Tps=
+golang.org/x/sys v0.0.0-20211031064116-611d5d643895/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210317153231-de623e64d2a6/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=

--- a/pkg/remote/monitor.go
+++ b/pkg/remote/monitor.go
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-package main
+package remote
 
 import (
 	"context"
@@ -16,8 +16,6 @@ import (
 	"os"
 	"os/exec"
 	"sync"
-
-	"github.com/linuxboot/contest/pkg/remote"
 )
 
 type Monitor struct {
@@ -232,7 +230,7 @@ func NewMonitorClient(pid int) *MonitorClient {
 	return &MonitorClient{addr}
 }
 
-func (m *MonitorClient) Poll() (*remote.PollMessage, error) {
+func (m *MonitorClient) Poll() (*PollMessage, error) {
 	client, err := rpc.DialHTTP("unix", m.addr)
 	if err != nil {
 		return nil, &ErrCantConnect{fmt.Errorf("failed to connect to %s: %w", m.addr, err)}
@@ -249,7 +247,7 @@ func (m *MonitorClient) Poll() (*remote.PollMessage, error) {
 		code = &reply.ExitCode
 	}
 
-	return &remote.PollMessage{
+	return &PollMessage{
 		Stdout:   string(reply.Stdout),
 		Stderr:   string(reply.Stderr),
 		ExitCode: code,

--- a/pkg/remote/proto.go
+++ b/pkg/remote/proto.go
@@ -1,0 +1,48 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package remote
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+type StartMessage struct {
+	SessionID string `json:"sid"`
+}
+
+type PollMessage struct {
+	Stdout string `json:"stdout,omitempty"`
+	Stderr string `json:"stderr,omitempty"`
+	Alive  bool   `json:"alive"`
+	Error  string `json:"error,omitempty"`
+}
+
+// SendResponse conveys to the caller a given response object o
+func SendResponse(o interface{}) error {
+	bytes, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Printf("%s\n", string(bytes))
+	return err
+}
+
+// RecvResponse reads a response object from the given reader
+func RecvResponse(r io.Reader, o interface{}) error {
+	s := bufio.NewScanner(r)
+	if !s.Scan() {
+		return fmt.Errorf("no input")
+	}
+	if s.Err() != nil {
+		return s.Err()
+	}
+
+	return json.Unmarshal(s.Bytes(), o)
+}

--- a/pkg/remote/proto.go
+++ b/pkg/remote/proto.go
@@ -19,8 +19,12 @@ type StartMessage struct {
 type PollMessage struct {
 	Stdout string `json:"stdout,omitempty"`
 	Stderr string `json:"stderr,omitempty"`
-	Alive  bool   `json:"alive"`
-	Error  string `json:"error,omitempty"`
+
+	// ExitCode is non-nil when the controlled process exited
+	ExitCode *int `json:"exitcode"`
+
+	// Error is any error encountered while trying to reach the agent
+	Error string `json:"error,omitempty"`
 }
 
 // SendResponse conveys to the caller a given response object o

--- a/pkg/remote/proto_test.go
+++ b/pkg/remote/proto_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package remote
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendResponseSimple(t *testing.T) {
+	prev := os.Stdout
+	defer func() {
+		os.Stdout = prev
+	}()
+
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	result := make(chan []byte)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		result <- buf.Bytes()
+	}()
+
+	sid := "42"
+	err := SendResponse(&StartMessage{sid})
+	require.NoError(t, err)
+
+	// done with capturing stdout
+	w.Close()
+
+	var recv StartMessage
+	err = json.Unmarshal(<-result, &recv)
+	require.NoError(t, err)
+
+	require.Equal(t, sid, recv.SessionID)
+}
+
+func TestRecvResponseSimple(t *testing.T) {
+	msg := StartMessage{"42"}
+	data, err := json.Marshal(&msg)
+	require.NoError(t, err)
+
+	var recv StartMessage
+	err = RecvResponse(bytes.NewReader(data), &recv)
+	require.NoError(t, err)
+
+	require.Equal(t, msg, recv)
+}

--- a/pkg/remote/sync.go
+++ b/pkg/remote/sync.go
@@ -3,7 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-package main
+package remote
 
 import (
 	"bytes"

--- a/pkg/remote/sync_test.go
+++ b/pkg/remote/sync_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package remote
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafeSignalSimple(t *testing.T) {
+	s := newSafeSignal()
+	c := make(chan struct{})
+
+	go func() {
+		s.Wait()
+		close(c)
+	}()
+
+	s.Signal()
+
+	select {
+	case <-c:
+		return
+
+	case <-time.After(time.Second):
+		t.Fail()
+	}
+}
+
+func TestSafeSignalMultipleSignal(t *testing.T) {
+	s := newSafeSignal()
+
+	// should not panic on multiple signal calls
+	defer func() {
+		if err := recover(); err != nil {
+			t.Fail()
+		}
+	}()
+
+	s.Signal()
+	s.Signal()
+}
+
+func TestSafeBufferSimple(t *testing.T) {
+	var b SafeBuffer
+	require.Equal(t, 0, b.Len())
+
+	data := []byte{1, 2, 3}
+	n, err := b.Write(data)
+
+	require.NoError(t, err)
+	require.Equal(t, len(data), n)
+
+	read := make([]byte, len(data))
+	n, err = b.Read(read)
+
+	require.NoError(t, err)
+	require.Equal(t, len(data), n)
+	require.Equal(t, read, data)
+}
+
+func TestSafeExitCodeSimple(t *testing.T) {
+	var s SafeExitCode
+	require.Equal(t, (*int)(nil), s.Load())
+
+	s.Store(42)
+	require.Equal(t, 42, *s.Load())
+}

--- a/plugins/teststeps/exec/exec.go
+++ b/plugins/teststeps/exec/exec.go
@@ -34,6 +34,8 @@ type stepParams struct {
 	Constraints struct {
 		TimeQuota xjson.Duration `json:"time_quota,omitempty"`
 	} `json:"constraints,omitempty"`
+
+	ExitCodeMap map[int]string `json:"exitcode_map,omitempty"`
 }
 
 // Name is the name used to look this plugin up.

--- a/plugins/teststeps/exec/ocp_parser.go
+++ b/plugins/teststeps/exec/ocp_parser.go
@@ -196,6 +196,10 @@ func (p *OCPEventParser) parseStep(ctx xcontext.Context, node *StepArtifact, roo
 }
 
 func (ep *OCPEventParser) Parse(ctx xcontext.Context, root *OCPRoot) error {
+	if root == nil {
+		return fmt.Errorf("invalid nil root object")
+	}
+
 	if root.RunArtifact != nil {
 		return ep.parseRun(ctx, root.RunArtifact, root)
 	}

--- a/plugins/teststeps/exec/runner.go
+++ b/plugins/teststeps/exec/runner.go
@@ -54,11 +54,13 @@ func (r *TargetRunner) runWithOCP(
 	for dec.More() {
 		var root *OCPRoot
 		if err := dec.Decode(&root); err != nil {
-			ctx.Warnf("failed to decode ocp root: %w", err)
+			ctx.Warnf("failed to decode ocp json: %w", err)
+			break
 		}
 
 		if err := p.Parse(ctx, root); err != nil {
 			ctx.Warnf("failed to parse ocp root: %w", err)
+			break
 		}
 	}
 

--- a/plugins/teststeps/exec/transport/local_transport.go
+++ b/plugins/teststeps/exec/transport/local_transport.go
@@ -53,7 +53,7 @@ func (lp *localProcess) Wait(_ xcontext.Context) error {
 	if err := lp.cmd.Wait(); err != nil {
 		var e *exec.ExitError
 		if errors.As(err, &e) {
-			return fmt.Errorf("process exited with error: %w", err)
+			return &ExitError{e.ExitCode()}
 		}
 
 		return fmt.Errorf("failed to wait on process: %w", err)

--- a/plugins/teststeps/exec/transport/ssh_process.go
+++ b/plugins/teststeps/exec/transport/ssh_process.go
@@ -109,7 +109,7 @@ func (sp *sshProcess) Wait(c xcontext.Context) error {
 	if err := sp.session.Wait(); err != nil {
 		var e *ssh.ExitError
 		if errors.As(err, &e) {
-			return fmt.Errorf("process exited with error: %w", e)
+			return &ExitError{e.ExitStatus()}
 		}
 
 		return fmt.Errorf("failed to wait on process: %w", err)

--- a/plugins/teststeps/exec/transport/ssh_process_async.go
+++ b/plugins/teststeps/exec/transport/ssh_process_async.go
@@ -246,7 +246,7 @@ func (m *asyncMonitor) Start(
 
 				code := *msg.ExitCode
 				if code != 0 {
-					exitChan <- fmt.Errorf("binary exited with non-zero code: %d", code)
+					exitChan <- &ExitError{code}
 				} else {
 					exitChan <- nil
 				}

--- a/plugins/teststeps/exec/transport/transport.go
+++ b/plugins/teststeps/exec/transport/transport.go
@@ -18,6 +18,16 @@ type Transport interface {
 	NewProcess(ctx xcontext.Context, bin string, args []string) (Process, error)
 }
 
+// ExitError is returned by Process.Wait when the controlled process exited with
+// a non-zero exit code (depending on transport)
+type ExitError struct {
+	ExitCode int
+}
+
+func (e *ExitError) Error() string {
+	return fmt.Sprintf("process exited with non-zero code: %d", e.ExitCode)
+}
+
 type Process interface {
 	Start(ctx xcontext.Context) error
 	Wait(ctx xcontext.Context) error


### PR DESCRIPTION
Add the exitcode_map step parameter and required refactoring to make that work.

Relevant commit messages:

- add remote.StartMessage and PollMessage to pass data from the remote agent back to the controller; this was initially raw text, and respectively using stdout and stderr to proxy the process outputs
- rename the wait operation to reap since it's only a trigger
- refactor monitor to have control over the process, this avoids the signal 0 sending to watch for process live state and also enables monitoring for the exit code
- add ExitCodeMap to exec step params; maps from exit code to error string
- add ExitError type to signal the exit code from the transports
- add integration tests for all the process types with exitcode map

Testing: manual testing and the integration tests
