### PR TITLE
Implement RunUntilSucceed job parameter that allows to run jub until success

### DIFF
--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -23,6 +23,7 @@ type Descriptor struct {
 	JobName                     string
 	Tags                        []string
 	Runs                        uint
+	RunUntilSucceed             bool
 	RunInterval                 xjson.Duration
 	TestDescriptors             []*test.TestDescriptor
 	Reporting                   Reporting
@@ -78,6 +79,10 @@ type Job struct {
 	// Runs to 2 will execute all the tests defined in `Tests` once, and then
 	// will execute them again.
 	Runs uint
+
+	// RunUntilSucceed if set to true will launch tests until all reporters will return succeeded status
+	// In this case Runs defines a maximum number of retries
+	RunUntilSucceed bool
 
 	// RunInterval is the interval between multiple runs, if more than one, or
 	// unlimited, are specified.

--- a/pkg/jobmanager/job.go
+++ b/pkg/jobmanager/job.go
@@ -110,6 +110,7 @@ func newJob(ctx xcontext.Context, registry *pluginregistry.PluginRegistry, jobDe
 		Name:                        jobDescriptor.JobName,
 		Tags:                        jobDescriptor.Tags,
 		Runs:                        jobDescriptor.Runs,
+		RunUntilSucceed:             jobDescriptor.RunUntilSucceed,
 		RunInterval:                 time.Duration(jobDescriptor.RunInterval),
 		TargetManagerAcquireTimeout: targetManagerAcquireTimeout,
 		TargetManagerReleaseTimeout: targetManagerReleaseTimeout,


### PR DESCRIPTION
In case a test can fail because of some random factor, it is nice to be able to launch it until success is reported.
I personally have this scenario when a target due to a random factor can become broken. So, I need to relaunch the test until it succeeds.

If this is ok, I will add unit tests for job runner