### PR TITLE
Order framework events by ID in jobmanager status/resume methods

### DIFF
--- a/pkg/event/frameworkevent/framework.go
+++ b/pkg/event/frameworkevent/framework.go
@@ -18,6 +18,7 @@ import (
 
 // Event represents an event emitted by the framework
 type Event struct {
+	ID        uint64
 	JobID     types.JobID
 	EventName event.Name
 	Payload   *json.RawMessage

--- a/plugins/storage/rdbms/events.go
+++ b/plugins/storage/rdbms/events.go
@@ -426,8 +426,7 @@ func (r *RDBMS) GetFrameworkEvent(ctx xcontext.Context, eventQuery *frameworkeve
 
 	for rows.Next() {
 		event := frameworkevent.New()
-		var eventID int
-		err := rows.Scan(&eventID, &event.JobID, &event.EventName, &event.Payload, &event.EmitTime)
+		err := rows.Scan(&event.ID, &event.JobID, &event.EventName, &event.Payload, &event.EmitTime)
 		if err != nil {
 			return nil, fmt.Errorf("could not read results from db: %v", err)
 		}


### PR DESCRIPTION
Because ID is a new field, we are breaking contracts (a bit)