### PR TITLE
Use EmitTime when ordering framework events

### DIFF
--- a/pkg/event/frameworkevent/framework.go
+++ b/pkg/event/frameworkevent/framework.go
@@ -18,7 +18,6 @@ import (
 
 // Event represents an event emitted by the framework
 type Event struct {
-	ID        uint64
 	JobID     types.JobID
 	EventName event.Name
 	Payload   *json.RawMessage

--- a/pkg/jobmanager/resume.go
+++ b/pkg/jobmanager/resume.go
@@ -49,7 +49,7 @@ func (jm *JobManager) resumeJob(ctx xcontext.Context, jobID types.JobID) error {
 	// get the latest event by id
 	var lastEventIdx int
 	for idx, ev := range results {
-		if ev.ID > results[lastEventIdx].ID {
+		if ev.EmitTime.After(results[lastEventIdx].EmitTime) {
 			lastEventIdx = idx
 		}
 	}

--- a/pkg/jobmanager/status.go
+++ b/pkg/jobmanager/status.go
@@ -97,7 +97,7 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 				endTime = &ev.EmitTime
 			}
 		}
-		if ev.ID > jobEvents[lastJobEventIdx].ID {
+		if ev.EmitTime.After(jobEvents[lastJobEventIdx].EmitTime) {
 			lastJobEventIdx = idx
 		}
 	}

--- a/plugins/storage/rdbms/events.go
+++ b/plugins/storage/rdbms/events.go
@@ -426,7 +426,8 @@ func (r *RDBMS) GetFrameworkEvent(ctx xcontext.Context, eventQuery *frameworkeve
 
 	for rows.Next() {
 		event := frameworkevent.New()
-		err := rows.Scan(&event.ID, &event.JobID, &event.EventName, &event.Payload, &event.EmitTime)
+		var eventID int
+		err := rows.Scan(&eventID, &event.JobID, &event.EventName, &event.Payload, &event.EmitTime)
 		if err != nil {
 			return nil, fmt.Errorf("could not read results from db: %v", err)
 		}


### PR DESCRIPTION
I saw that EmitTime is used throughout ConTest, if we want to use other mechanisms for consistency, we should redesign