### PR TITLE
Refactor implement step runner

### DIFF
--- a/pkg/cerrors/cerrors.go
+++ b/pkg/cerrors/cerrors.go
@@ -44,6 +44,16 @@ func (e *ErrTestStepPaniced) Error() string {
 	return fmt.Sprintf("test step %s paniced, trace: %q", e.StepName, e.StackTrace)
 }
 
+// ErrTestStepReturnedNoTarget indicates that a test step returned nil Target
+type ErrTestStepReturnedNoTarget struct {
+	StepName string
+}
+
+// Error returns the error string associated with the error
+func (e *ErrTestStepReturnedNoTarget) Error() string {
+	return fmt.Sprintf("test step %s returned nil result", e.StepName)
+}
+
 // ErrTestStepReturnedDuplicateResult indicates that a test step returned result
 // twice for the same target.
 type ErrTestStepReturnedDuplicateResult struct {

--- a/pkg/cerrors/cerrors.go
+++ b/pkg/cerrors/cerrors.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 )
 
+// ErrAlreadyDone indicates that action already happened
 type ErrAlreadyDone struct {
 }
 

--- a/pkg/cerrors/cerrors.go
+++ b/pkg/cerrors/cerrors.go
@@ -10,6 +10,13 @@ import (
 	"strings"
 )
 
+type ErrAlreadyDone struct {
+}
+
+func (e *ErrAlreadyDone) Error() string {
+	return "already done"
+}
+
 // ErrTestStepsNeverReturned indicates that one or multiple TestSteps
 //  did not complete when the test terminated or when the pipeline
 // received a cancellation or pause signal

--- a/pkg/runner/base_test_suite_test.go
+++ b/pkg/runner/base_test_suite_test.go
@@ -1,0 +1,61 @@
+package runner
+
+import (
+	"encoding/json"
+
+	"github.com/benbjohnson/clock"
+	"github.com/linuxboot/contest/pkg/event/testevent"
+	"github.com/linuxboot/contest/pkg/pluginregistry"
+	"github.com/linuxboot/contest/pkg/target"
+	"github.com/linuxboot/contest/pkg/test"
+	"github.com/linuxboot/contest/pkg/xcontext"
+	"github.com/linuxboot/contest/plugins/targetlocker/inmemory"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type BaseTestSuite struct {
+	suite.Suite
+
+	pluginRegistry  *pluginregistry.PluginRegistry
+	internalStorage *MemoryStorageEngine
+}
+
+func (s *BaseTestSuite) SetupTest() {
+	storageEngine, err := NewMemoryStorageEngine()
+	require.NoError(s.T(), err)
+	s.internalStorage = storageEngine
+
+	target.SetLocker(inmemory.New(clock.New()))
+
+	s.pluginRegistry = pluginregistry.NewPluginRegistry(xcontext.Background())
+}
+
+func (s *BaseTestSuite) TearDownTest() {
+	target.SetLocker(nil)
+}
+
+func (s *BaseTestSuite) RegisterStateFullStep(
+	runFunction func(
+		ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters,
+		ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error),
+	validateFunction func(ctx xcontext.Context, params test.TestStepParameters) error) error {
+
+	return s.pluginRegistry.RegisterTestStep(stateFullStepName, func() test.TestStep {
+		return &stateFullStep{
+			runFunction:      runFunction,
+			validateFunction: validateFunction,
+		}
+	}, nil)
+}
+
+func (s *BaseTestSuite) NewStep(label, name string, params test.TestStepParameters) test.TestStepBundle {
+	td := test.TestStepDescriptor{
+		Name:       name,
+		Label:      label,
+		Parameters: params,
+	}
+	sb, err := s.pluginRegistry.NewTestStepBundle(ctx, td)
+	require.NoError(s.T(), err)
+	return *sb
+}

--- a/pkg/runner/step_runner.go
+++ b/pkg/runner/step_runner.go
@@ -19,17 +19,19 @@ type OnTargetResult func(tgt *target.Target, res error)
 type OnStepRunnerStopped func(err error)
 
 type StepRunner struct {
-	ctx            xcontext.Context
-	cancel         context.CancelFunc
-	mu             sync.Mutex
+	ctx    xcontext.Context
+	cancel context.CancelFunc
+	mu     sync.Mutex
+
 	targetCallback OnTargetResult
 	stopCallback   OnStepRunnerStopped
 
-	stepIn            chan *target.Target
-	stopOnce          sync.Once
-	reportedTargets   map[string]struct{}
+	stepIn          chan *target.Target
+	reportedTargets map[string]struct{}
+
 	started           uint32
 	runningLoopActive bool
+	stopOnce          sync.Once
 	finishedCh        chan struct{}
 
 	resultErr         error
@@ -37,7 +39,6 @@ type StepRunner struct {
 }
 
 func (sr *StepRunner) AddTarget(tgt *target.Target) error {
-	// check if running
 	select {
 	case sr.stepIn <- tgt:
 	case <-sr.ctx.Until(xcontext.ErrPaused):

--- a/pkg/runner/step_runner.go
+++ b/pkg/runner/step_runner.go
@@ -1,0 +1,271 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"runtime/debug"
+	"sync"
+
+	"github.com/linuxboot/contest/pkg/cerrors"
+	"github.com/linuxboot/contest/pkg/event/testevent"
+	"github.com/linuxboot/contest/pkg/target"
+	"github.com/linuxboot/contest/pkg/test"
+	"github.com/linuxboot/contest/pkg/xcontext"
+)
+
+type OnTargetResult func(res error)
+type OnStepRunnerStopped func(err error)
+
+type StepRunner struct {
+	ctx xcontext.Context
+	cancel context.CancelFunc
+	mu  sync.Mutex
+	stopCallback OnStepRunnerStopped
+
+	stepIn chan *target.Target
+	addedTargets map[string]OnTargetResult
+
+	stepStopped  chan struct{}
+	resultErr    error
+	resultResumeState json.RawMessage
+}
+
+func (sr *StepRunner) AddTarget(tgt *target.Target, callback OnTargetResult) error {
+	if callback == nil {
+		return fmt.Errorf("callback should not be nil")
+	}
+	err := func(tgt *target.Target, callback OnTargetResult) error {
+		sr.mu.Lock()
+		defer sr.mu.Unlock()
+
+		if sr.ctx.Err() != nil {
+			return sr.ctx.Err()
+		}
+
+		if sr.stepIn == nil {
+			return fmt.Errorf("step runner is stepStopped")
+		}
+
+		existingCb := sr.addedTargets[tgt.ID]
+		if existingCb != nil {
+			return fmt.Errorf("existing target")
+		}
+		sr.addedTargets[tgt.ID] = callback
+		return nil
+	}(tgt, callback)
+	if err != nil {
+		return err
+	}
+
+	// check if running
+	select {
+	case sr.stepIn <- tgt:
+	case <-sr.ctx.Until(xcontext.ErrPaused):
+		return xcontext.ErrPaused
+	case <-sr.ctx.Done():
+		return sr.ctx.Err()
+	}
+	return nil
+}
+
+func (sr *StepRunner) IsRunning() bool {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	return sr.stepStopped != nil
+}
+
+func (sr *StepRunner) WaitResults(ctx context.Context) (json.RawMessage, error) {
+	sr.mu.Lock()
+	resultErr := sr.resultErr
+	resultResumeState := sr.resultResumeState
+	stepStopped := sr.stepStopped
+	sr.mu.Unlock()
+
+	if resultErr != nil {
+		return resultResumeState, resultErr
+	}
+
+	if stepStopped != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-stepStopped:
+		}
+	}
+
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	return sr.resultResumeState, sr.resultErr
+}
+
+// Stop triggers TestStep to stop running by closing input channel
+func (sr *StepRunner) Stop() {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
+	if sr.stepIn != nil {
+		sr.ctx.Debugf("Close input channel")
+		close(sr.stepIn)
+		sr.stepIn = nil
+	}
+}
+
+func (sr *StepRunner) readingLoop(stepOut chan test.TestStepResult, testStepLabel string) {
+	invokePanicSafe := func(callback OnTargetResult, res error) {
+		if r := recover(); r != nil {
+			sr.ctx.Errorf("Callback panic, stack: %s", debug.Stack())
+		}
+		callback(res)
+	}
+
+	for {
+		select {
+		case res, ok := <-stepOut:
+			if !ok {
+				sr.ctx.Debugf("Output channel closed")
+
+				if sr.IsRunning() {
+					// This means that plugin closed its channels before leaving.
+					sr.setErr(&cerrors.ErrTestStepClosedChannels{StepName: testStepLabel})
+				}
+				return
+			}
+
+			if res.Target == nil {
+				sr.setErr(&cerrors.ErrTestStepReturnedNoTarget{StepName: testStepLabel})
+				return
+			}
+
+			sr.mu.Lock()
+			callback, found := sr.addedTargets[res.Target.ID]
+			sr.addedTargets[res.Target.ID] = nil
+			sr.mu.Unlock()
+
+			if !found {
+				sr.setErr(&cerrors.ErrTestStepReturnedUnexpectedResult{StepName: testStepLabel, Target: res.Target.ID})
+				return
+			}
+			if callback == nil {
+				sr.setErr(&cerrors.ErrTestStepReturnedDuplicateResult{StepName: testStepLabel, Target: res.Target.ID})
+				return
+			}
+			invokePanicSafe(callback, res.Err)
+
+		case <- sr.ctx.Done():
+			sr.ctx.Debugf("canceled readingLoop")
+			return
+		}
+	}
+}
+
+func (sr *StepRunner) runningLoop(
+	stepIn chan *target.Target, stepOut chan test.TestStepResult,
+	bundle test.TestStepBundle, ev testevent.Emitter, resumeState json.RawMessage,
+) {
+	defer func() {
+		if recoverOccurred := safeCloseOutCh(stepOut); recoverOccurred {
+			sr.setErr(&cerrors.ErrTestStepClosedChannels{StepName: bundle.TestStepLabel})
+		}
+	}()
+
+	defer func() {
+		if r := recover(); r != nil {
+			sr.mu.Lock()
+			sr.setErrLocked(&cerrors.ErrTestStepPaniced{
+				StepName:   bundle.TestStepLabel,
+				StackTrace: fmt.Sprintf("%s / %s", r, debug.Stack()),
+			})
+			close(sr.stepStopped)
+			sr.stepStopped = nil
+			sr.mu.Unlock()
+		}
+	}()
+
+	inChannels := test.TestStepChannels{In: stepIn, Out: stepOut}
+	resultResumeState, err := bundle.TestStep.Run(sr.ctx, inChannels, bundle.Parameters, ev, resumeState)
+	sr.ctx.Debugf("%s: step runner finished %v, rs %s", bundle.TestStepLabel, err, string(resultResumeState))
+
+	sr.mu.Lock()
+	sr.setErrLocked(err)
+	sr.resultResumeState = resultResumeState
+	close(sr.stepStopped)
+	sr.stepStopped = nil
+	sr.notifyStoppedLocked(nil)
+	sr.mu.Unlock()
+}
+
+// setErr sets step runner error unless already set.
+func (sr *StepRunner) setErr(err error) {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	sr.setErrLocked(err)
+}
+
+func (sr *StepRunner) setErrLocked(err error) {
+	if err == nil || sr.resultErr != nil {
+		return
+	}
+	sr.ctx.Errorf("err: %v", err)
+	sr.resultErr = err
+	sr.notifyStoppedLocked(sr.resultErr)
+}
+
+func (sr *StepRunner) notifyStoppedLocked(err error) {
+	sr.cancel()
+	if sr.stopCallback == nil {
+		return
+	}
+	stopCallback := sr.stopCallback
+	sr.stopCallback = nil
+
+	go func() {
+		if r := recover(); r != nil {
+			sr.ctx.Errorf("Stop callback panic, stack: %s", debug.Stack())
+		}
+		stopCallback(err)
+	}()
+}
+
+func safeCloseOutCh(ch chan test.TestStepResult) (recoverOccurred bool) {
+	recoverOccurred = false
+	defer func() {
+		if r := recover(); r != nil {
+			recoverOccurred = true
+		}
+	}()
+	close(ch)
+	return
+}
+
+// NewStepRunner creates a new StepRunner object
+func NewStepRunner(
+	ctx xcontext.Context,
+	bundle test.TestStepBundle,
+	ev testevent.Emitter,
+	resumeState json.RawMessage,
+	stoppedCallback OnStepRunnerStopped,
+) *StepRunner {
+	stepIn := make(chan *target.Target)
+	stepOut := make(chan test.TestStepResult)
+
+	srCrx, cancel := xcontext.WithCancel(ctx)
+	sr := &StepRunner{
+		ctx:          srCrx,
+		cancel:       cancel,
+		stepIn:       stepIn,
+		addedTargets: make(map[string]OnTargetResult),
+		stepStopped:  make(chan struct{}),
+		stopCallback: stoppedCallback,
+	}
+
+	go func() {
+		sr.runningLoop(stepIn, stepOut, bundle, ev, resumeState)
+	}()
+
+	go func() {
+		sr.readingLoop(stepOut, bundle.TestStepLabel)
+	}()
+	return sr
+}

--- a/pkg/runner/step_runner_test.go
+++ b/pkg/runner/step_runner_test.go
@@ -1,0 +1,100 @@
+package runner
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/linuxboot/contest/pkg/event/testevent"
+	"github.com/linuxboot/contest/pkg/target"
+	"github.com/linuxboot/contest/pkg/test"
+	"github.com/linuxboot/contest/pkg/xcontext"
+	"github.com/linuxboot/contest/plugins/teststeps"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestStepRunnerSuite(t *testing.T) {
+	suite.Run(t, new(StepRunnerSuite))
+}
+
+type StepRunnerSuite struct {
+	BaseTestSuite
+}
+
+func (s *StepRunnerSuite) TestRunningStep() {
+	targetsReaction := map[string]error{
+		"TSucc": nil,
+		"TFail": fmt.Errorf("oops"),
+	}
+
+	var mu sync.Mutex
+	var obtainedTargets []target.Target
+	var obtainedResumeState json.RawMessage
+
+	err := s.RegisterStateFullStep(
+		func(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
+			obtainedResumeState = resumeState
+			_, err := teststeps.ForEachTarget(stateFullStepName, ctx, ch, func(ctx xcontext.Context, target *target.Target) error {
+				require.NotNil(s.T(), target)
+
+				mu.Lock()
+				defer mu.Unlock()
+				obtainedTargets = append(obtainedTargets, *target)
+				return targetsReaction[target.ID]
+			})
+			if err != nil {
+				return nil, err
+			}
+			return json.RawMessage("{\"output\": true}"), nil
+		},
+		nil,
+	)
+	require.NoError(s.T(), err)
+
+	stepRunner := NewStepRunner()
+	require.NotNil(s.T(), stepRunner)
+
+	emitterFactory := NewTestStepEventsEmitterFactory(s.internalStorage.StorageEngineVault, 1, 1, testName, 0)
+	emitter := emitterFactory.New("test_step_label")
+
+	inputResumeState := json.RawMessage("{\"some_input\": 42}")
+	resultChan, err := stepRunner.Run(ctx, s.NewStep("test_step_label", stateFullStepName, nil), emitter, inputResumeState)
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), resultChan)
+
+	require.NoError(s.T(), stepRunner.AddTarget(ctx, tgt("TSucc")))
+	ev, ok := <-resultChan
+	require.True(s.T(), ok)
+	require.Equal(s.T(), tgt("TSucc"), ev.Target)
+	require.NoError(s.T(), ev.Err)
+
+	require.NoError(s.T(), stepRunner.AddTarget(ctx, tgt("TFail")))
+	ev, ok = <-resultChan
+	require.True(s.T(), ok)
+	require.Equal(s.T(), tgt("TFail"), ev.Target)
+	require.Error(s.T(), ev.Err)
+
+	stepRunner.Stop()
+
+	ev, ok = <-resultChan
+	require.True(s.T(), ok)
+	require.Nil(s.T(), ev.Target)
+	require.NoError(s.T(), ev.Err)
+
+	ev, ok = <-resultChan
+	require.False(s.T(), ok)
+
+	closedCtx, cancel := xcontext.WithCancel(ctx)
+	cancel()
+
+	// if step runner has results, it should return them even if input context is closed
+	res, err := stepRunner.WaitResults(closedCtx)
+	require.NoError(s.T(), err)
+
+	require.Equal(s.T(), json.RawMessage("{\"output\": true}"), res.ResumeState)
+	require.NoError(s.T(), res.Err)
+
+	require.Equal(s.T(), inputResumeState, obtainedResumeState)
+}

--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -59,6 +59,8 @@ type stepState struct {
 	stepIndex int                 // Index of this step in the pipeline.
 	sb        test.TestStepBundle // The test bundle.
 
+	stepRunner *StepRunner
+
 	// Channels used to communicate with the plugin.
 	inCh  chan *target.Target
 	outCh chan test.TestStepResult

--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -538,6 +538,7 @@ func (tr *TestRunner) runStepIfNeeded(ss *stepState) error {
 					return
 				}
 				if stepResult.Target == nil {
+					ss.ctx.Errorf("step runner results an err: %v", err)
 					tr.mu.Lock()
 					ss.setErrLocked(stepResult.Err)
 					tr.mu.Unlock()
@@ -564,7 +565,7 @@ func (ss *stepState) setErrLocked(err error) {
 	if err == nil || ss.runErr != nil {
 		return
 	}
-	ss.ctx.Errorf("err: %v", err)
+	ss.ctx.Errorf("setErrLocked: %v", err)
 	ss.runErr = err
 }
 

--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -254,7 +254,7 @@ func (tr *TestRunner) Run(
 		if stepErr != nil && stepErr != xcontext.ErrPaused {
 			resumeOk = false
 		}
-		ctx.Debugf("  %d %s %v %t", i, tgs.String(), stepErr, resumeOk)
+		ctx.Debugf("  %d %s %v %t", i, tgs, stepErr, resumeOk)
 	}
 	ctx.Debugf("- %d in flight, ok to resume? %t", numInFlightTargets, resumeOk)
 	ctx.Debugf("step states:")
@@ -635,11 +635,11 @@ func (tr *TestRunner) runMonitor(ctx xcontext.Context, minStep int) error {
 stepLoop:
 	for step := minStep; step < len(tr.steps); pass++ {
 		ss := tr.steps[step]
-		ctx.Debugf("monitor pass %d: current step %s", pass, ss.String())
+		ctx.Debugf("monitor pass %d: current step %s", pass, ss)
 		// Check if all the targets have either made it past the injection phase or terminated.
 		ok := true
 		for _, tgs := range tr.targets {
-			ctx.Debugf("monitor pass %d: %s: %s", pass, ss, tgs.String())
+			ctx.Debugf("monitor pass %d: %s: %s", pass, ss, tgs)
 			if !tgs.handlerRunning { // Not running anymore
 				continue
 			}
@@ -750,5 +750,5 @@ func (tgs *targetState) String() string {
 	}
 	finished := !tgs.handlerRunning
 	return fmt.Sprintf("[%s %d %s %t %s]",
-		tgs.tgt, tgs.CurStep, tgs.CurPhase.String(), finished, resText)
+		tgs.tgt, tgs.CurStep, tgs.CurPhase, finished, resText)
 }

--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -333,7 +333,7 @@ func (tr *TestRunner) injectTarget(ctx xcontext.Context, tgs *targetState, ss *s
 	ctx.Debugf("%s: injecting into %s", tgs, ss)
 
 	tgt := tgs.tgt
-	err := ss.stepRunner.AddTarget(tgt)
+	err := ss.stepRunner.AddTarget(ctx, tgt)
 	if err == nil {
 		if err = ss.emitEvent(ctx, target.EventTargetIn, tgs.tgt, nil); err != nil {
 			err = fmt.Errorf("failed to report target injection: %w", err)
@@ -591,11 +591,7 @@ func (tr *TestRunner) reportTargetResult(ctx xcontext.Context, ss *stepState, tg
 	}
 
 	// As it has buffer size 1 and we process a single result for each target at a time
-	select {
-	case resCh <- res:
-	default:
-		panic("WOW")
-	}
+	resCh <- res
 	return nil
 }
 

--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -515,7 +515,12 @@ loop:
 
 // runStepIfNeeded starts the step runner goroutine if not already running.
 func (tr *TestRunner) runStepIfNeeded(ss *stepState) {
-	ss.stepRunner.Run(ss.sb, ss.ev, ss.resumeState)
+	tr.mu.Lock()
+	resumeState := ss.resumeState
+	ss.resumeState = nil
+	tr.mu.Unlock()
+
+	ss.stepRunner.Run(ss.sb, ss.ev, resumeState)
 }
 
 // setErrLocked sets step runner error unless already set.

--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -509,12 +509,6 @@ func (tr *TestRunner) runStepIfNeeded(ss *stepState) {
 	})
 }
 
-func (ss *stepState) setErr(mu sync.Locker, err error) {
-	mu.Lock()
-	defer mu.Unlock()
-	ss.setErrLocked(err)
-}
-
 // setErrLocked sets step runner error unless already set.
 func (ss *stepState) setErrLocked(err error) {
 	if err == nil || ss.runErr != nil {

--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -588,12 +588,9 @@ func (tr *TestRunner) reportTargetResult(ss *stepState, tgt *target.Target, res 
 	if err != nil {
 		return err
 	}
-	select {
-	case resCh <- res:
-		break
-	case <-ss.ctx.Done():
-		break
-	}
+
+	// As it has buffer size 1 and we process a single result for each target at a time
+	resCh <- res
 	return nil
 }
 

--- a/pkg/runner/test_runner_test.go
+++ b/pkg/runner/test_runner_test.go
@@ -341,7 +341,7 @@ func (s *TestRunnerSuite) TestNoReturnStepWithCorrectTargetForwarding() {
 	tr := NewTestRunnerWithTimeouts(200 * time.Millisecond)
 	ctx, cancel := xcontext.WithCancel(ctx)
 	defer cancel()
-	_, _, err := s.runWithTimeout(ctx, tr, nil, 1, 2*time.Hour,
+	_, _, err := s.runWithTimeout(ctx, tr, nil, 1, 2*time.Second,
 		[]*target.Target{tgt("T1")},
 		[]test.TestStepBundle{
 			s.newStep("Step 1", noreturn.Name, nil),

--- a/pkg/runner/test_runner_test.go
+++ b/pkg/runner/test_runner_test.go
@@ -73,7 +73,7 @@ type runRes struct {
 }
 
 type MemoryStorageEngine struct {
-	Storage storage.ResettableStorage
+	Storage            storage.ResettableStorage
 	StorageEngineVault *storage.SimpleEngineVault
 }
 
@@ -89,7 +89,7 @@ func NewMemoryStorageEngine() (*MemoryStorageEngine, error) {
 	}
 
 	return &MemoryStorageEngine{
-		Storage: ms,
+		Storage:            ms,
 		StorageEngineVault: storageEngineVault,
 	}, nil
 }
@@ -206,7 +206,7 @@ func (s *TestRunnerSuite) Test1Step1Success() {
 	require.Equal(s.T(), `
 {[1 1 SimpleTest 0 Step 1][(*Target)(nil) TestStepRunningEvent]}
 {[1 1 SimpleTest 0 Step 1][(*Target)(nil) TestStepFinishedEvent]}
-`, s.internalStorage.GetStepEvents(testName,""))
+`, s.internalStorage.GetStepEvents(testName, ""))
 	require.Equal(s.T(), `
 {[1 1 SimpleTest 0 Step 1][Target{ID: "T1"} TargetIn]}
 {[1 1 SimpleTest 0 Step 1][Target{ID: "T1"} TestStartedEvent]}
@@ -218,7 +218,7 @@ func (s *TestRunnerSuite) Test1Step1Success() {
 // Simple case: one target, one step that blocks for a bit, success.
 // We block for longer than the shutdown timeout of the test runner.
 func (s *TestRunnerSuite) Test1StepLongerThanShutdown1Success() {
-	tr := NewTestRunnerWithTimeouts(100*time.Millisecond)
+	tr := NewTestRunnerWithTimeouts(100 * time.Millisecond)
 	_, targetsResults, err := s.runWithTimeout(ctx, tr, nil, 1, 2*time.Second,
 		[]*target.Target{tgt("T1")},
 		[]test.TestStepBundle{
@@ -239,7 +239,7 @@ func (s *TestRunnerSuite) Test1StepLongerThanShutdown1Success() {
 {[1 1 SimpleTest 0 Step 1][Target{ID: "T1"} TestStartedEvent]}
 {[1 1 SimpleTest 0 Step 1][Target{ID: "T1"} TestFinishedEvent]}
 {[1 1 SimpleTest 0 Step 1][Target{ID: "T1"} TargetOut]}
-`, s.internalStorage.GetTargetEvents(testName,"T1"))
+`, s.internalStorage.GetTargetEvents(testName, "T1"))
 }
 
 // Simple case: one target, one step, failure.
@@ -258,7 +258,7 @@ func (s *TestRunnerSuite) Test1Step1Fail() {
 	require.Equal(s.T(), `
 {[1 1 SimpleTest 0 Step 1][(*Target)(nil) TestStepRunningEvent]}
 {[1 1 SimpleTest 0 Step 1][(*Target)(nil) TestStepFinishedEvent]}
-`, s.internalStorage.GetStepEvents(testName,"Step 1"))
+`, s.internalStorage.GetStepEvents(testName, "Step 1"))
 	require.Equal(s.T(), `
 {[1 1 SimpleTest 0 Step 1][Target{ID: "T1"} TargetIn]}
 {[1 1 SimpleTest 0 Step 1][Target{ID: "T1"} TestStartedEvent]}
@@ -316,7 +316,7 @@ func (s *TestRunnerSuite) Test3StepsNotReachedStepNotRun() {
 {[1 1 SimpleTest 0 Step 2][(*Target)(nil) TestStepRunningEvent]}
 {[1 1 SimpleTest 0 Step 2][(*Target)(nil) TestStepFinishedEvent]}
 `, s.internalStorage.GetStepEvents(testName, "Step 2"))
-	require.Equal(s.T(), "\n\n", s.internalStorage.GetStepEvents(testName,"Step 3"))
+	require.Equal(s.T(), "\n\n", s.internalStorage.GetStepEvents(testName, "Step 3"))
 	require.Equal(s.T(), `
 {[1 1 SimpleTest 0 Step 1][Target{ID: "T1"} TargetIn]}
 {[1 1 SimpleTest 0 Step 1][Target{ID: "T1"} TestStartedEvent]}
@@ -338,10 +338,10 @@ func (s *TestRunnerSuite) Test3StepsNotReachedStepNotRun() {
 // A misbehaving step that fails to shut down properly after processing targets
 // and does not return.
 func (s *TestRunnerSuite) TestNoReturnStepWithCorrectTargetForwarding() {
-	tr := NewTestRunnerWithTimeouts(200*time.Millisecond)
+	tr := NewTestRunnerWithTimeouts(200 * time.Millisecond)
 	ctx, cancel := xcontext.WithCancel(ctx)
 	defer cancel()
-	_, _, err := s.runWithTimeout(ctx, tr, nil, 1, 2*time.Second,
+	_, _, err := s.runWithTimeout(ctx, tr, nil, 1, 2*time.Hour,
 		[]*target.Target{tgt("T1")},
 		[]test.TestStepBundle{
 			s.newStep("Step 1", noreturn.Name, nil),
@@ -363,7 +363,7 @@ func (s *TestRunnerSuite) TestStepPanics() {
 	)
 	require.Error(s.T(), err)
 	require.IsType(s.T(), &cerrors.ErrTestStepPaniced{}, err)
-	require.Equal(s.T(), "\n\n", s.internalStorage.GetTargetEvents(testName,"T1"))
+	require.Equal(s.T(), "\n\n", s.internalStorage.GetTargetEvents(testName, "T1"))
 	require.Contains(s.T(), s.internalStorage.GetStepEvents(testName, "Step 1"), "step Step 1 paniced")
 }
 

--- a/tests/integ/plugins/testrunner_test.go
+++ b/tests/integ/plugins/testrunner_test.go
@@ -46,7 +46,7 @@ var (
 var (
 	pluginRegistry *pluginregistry.PluginRegistry
 	targets        []*target.Target
-	successTimeout = 5 * time.Second
+	successTimeout = 20 * time.Second
 )
 
 var testSteps = map[string]test.TestStepFactory{


### PR DESCRIPTION
Move all logic that manages running of a TestStep in a separate TestRunner.
This refactoring is needed to make retries of steps look better.

Special thanks to @rojer for a large number of unit tests :)