### PR TITLE
Implement ordering of Events by using sequential IDs

### DIFF
--- a/pkg/event/frameworkevent/framework.go
+++ b/pkg/event/frameworkevent/framework.go
@@ -18,11 +18,12 @@ import (
 
 // Event represents an event emitted by the framework
 type Event struct {
-	ID        uint64
-	JobID     types.JobID
-	EventName event.Name
-	Payload   *json.RawMessage
-	EmitTime  time.Time
+	// SequenceID represents an ordering parameter between events of the same job
+	SequenceID uint64
+	JobID      types.JobID
+	EventName  event.Name
+	Payload    *json.RawMessage
+	EmitTime   time.Time
 }
 
 // New creates a new FrameworkEvent

--- a/pkg/event/testevent/test.go
+++ b/pkg/event/testevent/test.go
@@ -37,9 +37,11 @@ type Data struct {
 
 // Event models an event object that can be emitted by a TestStep
 type Event struct {
-	EmitTime time.Time
-	Header   *Header
-	Data     *Data
+	// SequenceID represents an ordering parameter between events of the same job
+	SequenceID uint64
+	EmitTime   time.Time
+	Header     *Header
+	Data       *Data
 }
 
 // New creates a new Event with zero value header and data

--- a/pkg/jobmanager/resume.go
+++ b/pkg/jobmanager/resume.go
@@ -49,7 +49,7 @@ func (jm *JobManager) resumeJob(ctx xcontext.Context, jobID types.JobID) error {
 	// get the latest event by id
 	var lastEventIdx int
 	for idx, ev := range results {
-		if ev.ID > results[lastEventIdx].ID {
+		if ev.SequenceID > results[lastEventIdx].SequenceID {
 			lastEventIdx = idx
 		}
 	}

--- a/pkg/jobmanager/status.go
+++ b/pkg/jobmanager/status.go
@@ -97,7 +97,7 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 				endTime = &ev.EmitTime
 			}
 		}
-		if ev.ID > jobEvents[lastJobEventIdx].ID {
+		if ev.SequenceID > jobEvents[lastJobEventIdx].SequenceID {
 			lastJobEventIdx = idx
 		}
 	}

--- a/plugins/storage/memory/memory.go
+++ b/plugins/storage/memory/memory.go
@@ -62,6 +62,7 @@ func emptyTestEventQuery(eventQuery *testevent.Query) bool {
 func (m *Memory) StoreTestEvent(_ xcontext.Context, event testevent.Event) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
+	event.SequenceID = uint64(len(m.testEvents)) + 1
 	m.testEvents = append(m.testEvents, event)
 	return nil
 }
@@ -296,6 +297,7 @@ jobLoop:
 func (m *Memory) StoreFrameworkEvent(_ xcontext.Context, event frameworkevent.Event) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
+	event.SequenceID = uint64(len(m.frameworkEvents)) + 1
 	m.frameworkEvents = append(m.frameworkEvents, event)
 	return nil
 }

--- a/plugins/storage/rdbms/events.go
+++ b/plugins/storage/rdbms/events.go
@@ -279,11 +279,10 @@ func (r *RDBMS) GetTestEvents(ctx xcontext.Context, eventQuery *testevent.Query)
 	for rows.Next() {
 		data := testevent.Data{}
 		header := testevent.Header{}
-		event := testevent.New(&header, &data)
+		ev := testevent.New(&header, &data)
 
-		var eventID int
 		err := rows.Scan(
-			&eventID,
+			&ev.SequenceID,
 			&header.JobID,
 			&header.RunID,
 			&header.TestName,
@@ -292,7 +291,7 @@ func (r *RDBMS) GetTestEvents(ctx xcontext.Context, eventQuery *testevent.Query)
 			&data.EventName,
 			&targetID,
 			&payload,
-			&event.EmitTime,
+			&ev.EmitTime,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("could not read results from db: %v", err)
@@ -308,7 +307,7 @@ func (r *RDBMS) GetTestEvents(ctx xcontext.Context, eventQuery *testevent.Query)
 
 		}
 
-		results = append(results, event)
+		results = append(results, ev)
 	}
 	return results, nil
 }
@@ -426,7 +425,7 @@ func (r *RDBMS) GetFrameworkEvent(ctx xcontext.Context, eventQuery *frameworkeve
 
 	for rows.Next() {
 		event := frameworkevent.New()
-		err := rows.Scan(&event.ID, &event.JobID, &event.EventName, &event.Payload, &event.EmitTime)
+		err := rows.Scan(&event.SequenceID, &event.JobID, &event.EventName, &event.Payload, &event.EmitTime)
 		if err != nil {
 			return nil, fmt.Errorf("could not read results from db: %v", err)
 		}


### PR DESCRIPTION
Initial problem
We had a bug in Status() method of a JobManager that didn't do the ordering of events obtained from the storage, assuming that the last extracted event is the latest one.

We had a discussion and came to conclusion that the best approach of solving this problem is to ask Storage for an explicit monotonic SequenceID support (inside a single Job) for each events.

The client code of the Storage should use SequenceIDs to do the ordering between events.