### PR TITLE
fix(xcontext): Fix caller file detection in logrus

### DIFF
--- a/pkg/xcontext/logger/logadapter/logrus/fix_caller_hook.go
+++ b/pkg/xcontext/logger/logadapter/logrus/fix_caller_hook.go
@@ -40,7 +40,7 @@ func (fixCallerHook) Fire(entry *logrus.Entry) error {
 		return nil
 	}
 
-	if !strings.HasPrefix(entry.Caller.Function, "github.com/linuxboot/contest/pkg/xcontext") {
+	if !strings.Contains(entry.Caller.Function, "github.com/linuxboot/contest/pkg/xcontext") {
 		// if the value is already correct, then there's nothing to do.
 		return nil
 	}
@@ -51,7 +51,7 @@ func (fixCallerHook) Fire(entry *logrus.Entry) error {
 	frames := runtime.CallersFrames(programCounters[0:n])
 	for {
 		frame, more := frames.Next()
-		if !strings.HasPrefix(frame.Function, "github.com/linuxboot/contest/pkg/xcontext") &&
+		if !strings.Contains(frame.Function, "github.com/linuxboot/contest/pkg/xcontext") &&
 			!strings.Contains(strings.ToLower(frame.Function), "github.com/sirupsen/logrus") {
 			entry.Caller = &frame
 			return nil


### PR DESCRIPTION
In our internal building system there is an additional prefix for outside code. Which 

# Before
```
[2021-12-09T06:21:56.019-08:00 D minimal_logger.go:39] my trace ID is 029ed5eb-f2b7-442f-91d2-65002285b0cb
[2021-12-09T06:21:56.020-08:00 I minimal_logger.go:39] Registering target manager provtest
[2021-12-09T06:21:56.020-08:00 I minimal_logger.go:39] Registering target manager serf
[2021-12-09T06:21:56.020-08:00 I minimal_logger.go:39] Registering target manager vmleasing
[2021-12-09T06:21:56.020-08:00 I minimal_logger.go:39] Registering target manager targetlist
```

# After
```
[2021-12-09T06:24:05.440-08:00 D main.go:176] my trace ID is 0ad3a6a6-5312-4977-a95a-cb2864e93b56
[2021-12-09T06:24:05.440-08:00 I pluginregistry.go:63] Registering target manager basset2
[2021-12-09T06:24:05.441-08:00 I pluginregistry.go:63] Registering target manager provtest
[2021-12-09T06:24:05.441-08:00 I pluginregistry.go:63] Registering target manager serf
[2021-12-09T06:24:05.441-08:00 I pluginregistry.go:63] Registering target manager vmleasing
```