### PR TITLE
Invoke GC() before checking for leaked goroutines

### DIFF
--- a/tests/common/goroutine_leak_check/goroutine_leak_check.go
+++ b/tests/common/goroutine_leak_check/goroutine_leak_check.go
@@ -48,6 +48,7 @@ func CheckLeakedGoRoutines(funcWhitelist ...string) error {
 }
 
 func checkLeakedGoRoutines(funcWhitelist ...string) (string, error) {
+	runtime.GC() // this should invoke all finalizers
 	// Allow some time for dying routines to exit.
 	time.Sleep(20 * time.Millisecond)
 	// Get goroutine stacks


### PR DESCRIPTION
This should probably fix:

        	Error Trace:	teststeps_test.go:419
        	Error:      	Received unexpected error:
        	            	leaked goroutines:
        	            	  34 event_handler.go:188 github.com/linuxboot/contest/pkg/xcontext.(*ctxValue).addEventHandler.func1
        	            	    github.com/linuxboot/contest/pkg/xcontext.(*ctxValue).addEventHandler.func1(0xc000020af0)
        	            	    	/go/src/github.com/linuxboot/contest/pkg/xcontext/event_handler.go:188 +0x99
        	Test:       	TestForEachTargetWithResumeAllReturn
FAIL