### PR TITLE
Move emission of EventTargetIn/EventTargetOut/EventTargetErr to StepRunner

### DIFF
--- a/pkg/runner/step_runner.go
+++ b/pkg/runner/step_runner.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 
 	"github.com/linuxboot/contest/pkg/cerrors"
+	"github.com/linuxboot/contest/pkg/event"
 	"github.com/linuxboot/contest/pkg/event/testevent"
 	"github.com/linuxboot/contest/pkg/target"
 	"github.com/linuxboot/contest/pkg/test"
@@ -48,6 +49,8 @@ func (sr *StepRunner) AddTarget(ctx xcontext.Context, tgt *target.Target) error 
 
 	select {
 	case sr.input <- tgt:
+	case <-sr.finishedCh:
+		return fmt.Errorf("step runner is already stopped")
 	case <-ctx.Until(xcontext.ErrPaused):
 		return xcontext.ErrPaused
 	case <-ctx.Done():
@@ -61,6 +64,7 @@ func (sr *StepRunner) Run(
 	bundle test.TestStepBundle,
 	ev testevent.Emitter,
 	resumeState json.RawMessage,
+	resumeStateTargets []target.Target,
 ) (<-chan StepRunnerEvent, error) {
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
@@ -69,8 +73,6 @@ func (sr *StepRunner) Run(
 		return nil, &cerrors.ErrAlreadyDone{}
 	}
 
-	finishedCh := make(chan struct{})
-	sr.finishedCh = finishedCh
 	resultsChan := make(chan StepRunnerEvent, 1)
 	sr.resultsChan = resultsChan
 
@@ -82,7 +84,6 @@ func (sr *StepRunner) Run(
 
 		sr.mu.Lock()
 		close(sr.finishedCh)
-		sr.finishedCh = nil
 		sr.mu.Unlock()
 
 		// if an error occurred we already sent notification
@@ -91,7 +92,7 @@ func (sr *StepRunner) Run(
 		ctx.Debugf("StepRunner finished")
 	}
 
-	stepIn := sr.input
+	stepIn := make(chan *target.Target)
 	stepOut := make(chan test.TestStepResult)
 	go func() {
 		defer finish()
@@ -101,7 +102,7 @@ func (sr *StepRunner) Run(
 
 	go func() {
 		defer finish()
-		sr.readingLoop(ctx, stepOut, bundle.TestStepLabel)
+		sr.ioLoop(ctx, stepIn, stepOut, ev, bundle.TestStepLabel, resumeStateTargets)
 		ctx.Debugf("Reading loop finished")
 	}()
 
@@ -115,20 +116,12 @@ func (sr *StepRunner) Started() bool {
 	return sr.resultsChan != nil
 }
 
-func (sr *StepRunner) Running() bool {
-	sr.mu.Lock()
-	defer sr.mu.Unlock()
-
-	return sr.resultsChan != nil && sr.finishedCh != nil
-}
-
 // WaitResults returns TestStep.Run() output
 // It returns an error if and only if waiting was terminated by input ctx argument and returns ctx.Err()
 func (sr *StepRunner) WaitResults(ctx context.Context) (stepResult StepResult, err error) {
 	sr.mu.Lock()
 	resultErr := sr.resultErr
 	resultResumeState := sr.resultResumeState
-	finishedCh := sr.finishedCh
 	sr.mu.Unlock()
 
 	// StepRunner either finished with error or behaved incorrectly
@@ -140,12 +133,15 @@ func (sr *StepRunner) WaitResults(ctx context.Context) (stepResult StepResult, e
 		}, nil
 	}
 
-	if finishedCh != nil {
+	select {
+	case <-ctx.Done():
+		// give priority to returning results
 		select {
-		case <-ctx.Done():
+		case <-sr.finishedCh:
+		default:
 			return StepResult{}, ctx.Err()
-		case <-finishedCh:
 		}
+	case <-sr.finishedCh:
 	}
 
 	sr.mu.Lock()
@@ -163,14 +159,66 @@ func (sr *StepRunner) Stop() {
 	})
 }
 
-func (sr *StepRunner) readingLoop(
+func (sr *StepRunner) ioLoop(
 	ctx xcontext.Context,
+	stepIn chan<- *target.Target,
 	stepOut chan test.TestStepResult,
+	ev testevent.Emitter,
 	testStepLabel string,
+	resumeStateTargets []target.Target,
 ) {
-	reportedTargets := make(map[string]struct{})
+	defer func() {
+		if stepIn != nil {
+			close(stepIn)
+		}
+	}()
+
+	targetsInfo := make(map[string]int)
+	for _, resumeTarget := range resumeStateTargets {
+		targetsInfo[resumeTarget.ID]++
+	}
+
+	input := sr.input
+	var stepInTmp chan<- *target.Target
+	var inputTargets []*target.Target
+	var curInputTarget *target.Target
+
+	closeStepIn := func() {
+		stepInTmp = nil
+		curInputTarget = nil
+		if input == nil {
+			ctx.Debugf("Close step input channel")
+			close(stepIn)
+			stepIn = nil
+			inputTargets = nil
+		}
+	}
+
 	for {
 		select {
+		case tgt, ok := <-input:
+			if !ok {
+				input = nil
+				if len(inputTargets) == 0 {
+					closeStepIn()
+				}
+			} else {
+				stepInTmp = stepIn
+				inputTargets = append(inputTargets, tgt)
+				curInputTarget = inputTargets[len(inputTargets)-1]
+			}
+		case stepInTmp <- curInputTarget:
+			targetsInfo[curInputTarget.ID]++
+			if err := emitEvent(ctx, ev, target.EventTargetIn, curInputTarget, nil); err != nil {
+				sr.setErrLocked(ctx, fmt.Errorf("failed to report target injection: %w", err))
+			}
+
+			inputTargets = inputTargets[:len(inputTargets)-1]
+			if len(inputTargets) > 0 {
+				curInputTarget = inputTargets[len(inputTargets)-1]
+			} else {
+				closeStepIn()
+			}
 		case res, ok := <-stepOut:
 			if !ok {
 				ctx.Debugf("Output channel closed")
@@ -190,12 +238,29 @@ func (sr *StepRunner) readingLoop(
 			}
 			ctx.Infof("Obtained '%v' for target '%s'", res, res.Target.ID)
 
-			_, found := reportedTargets[res.Target.ID]
-			reportedTargets[res.Target.ID] = struct{}{}
-
-			if found {
+			cnt, found := targetsInfo[res.Target.ID]
+			if !found {
+				sr.setErr(ctx, &cerrors.ErrTestStepReturnedUnexpectedResult{
+					StepName: testStepLabel,
+					Target:   res.Target.ID,
+				})
+				return
+			}
+			if cnt <= 0 {
 				sr.setErr(ctx, &cerrors.ErrTestStepReturnedDuplicateResult{StepName: testStepLabel, Target: res.Target.ID})
 				return
+			}
+			targetsInfo[res.Target.ID] = cnt - 1
+
+			var err error
+			if res.Err == nil {
+				err = emitEvent(ctx, ev, target.EventTargetOut, res.Target, nil)
+			} else {
+				err = emitEvent(ctx, ev, target.EventTargetErr, res.Target, target.ErrPayload{Error: res.Err.Error()})
+			}
+			if err != nil {
+				ctx.Errorf("failed to emit event: %s", err)
+				sr.setErr(ctx, err)
 			}
 
 			select {
@@ -298,9 +363,29 @@ func safeCloseOutCh(ch chan test.TestStepResult) (recoverOccurred bool) {
 	return
 }
 
+// emitEvent emits the specified event with the specified JSON payload (if any).
+func emitEvent(ctx xcontext.Context, ev testevent.Emitter, name event.Name, tgt *target.Target, payload interface{}) error {
+	var payloadJSON *json.RawMessage
+	if payload != nil {
+		payloadBytes, jmErr := json.Marshal(payload)
+		if jmErr != nil {
+			return fmt.Errorf("failed to marshal event: %w", jmErr)
+		}
+		pj := json.RawMessage(payloadBytes)
+		payloadJSON = &pj
+	}
+	errEv := testevent.Data{
+		EventName: name,
+		Target:    tgt,
+		Payload:   payloadJSON,
+	}
+	return ev.Emit(ctx, errEv)
+}
+
 // NewStepRunner creates a new StepRunner object
 func NewStepRunner() *StepRunner {
 	return &StepRunner{
-		input: make(chan *target.Target),
+		input:      make(chan *target.Target, 1),
+		finishedCh: make(chan struct{}),
 	}
 }

--- a/pkg/runner/step_runner.go
+++ b/pkg/runner/step_runner.go
@@ -283,6 +283,7 @@ func (sr *StepRunner) outputLoop(
 			if err != nil {
 				ctx.Errorf("failed to emit event: %s", err)
 				sr.setErr(ctx, err)
+				return
 			}
 
 			select {

--- a/pkg/runner/step_runner_test.go
+++ b/pkg/runner/step_runner_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/linuxboot/contest/pkg/cerrors"
 	"github.com/linuxboot/contest/pkg/event/testevent"
 	"github.com/linuxboot/contest/pkg/target"
 	"github.com/linuxboot/contest/pkg/test"
@@ -23,6 +25,15 @@ func TestStepRunnerSuite(t *testing.T) {
 
 type StepRunnerSuite struct {
 	BaseTestSuite
+}
+
+func checkStoppedSuccessfully(t *testing.T, resultChan <-chan StepRunnerEvent) {
+	ev := <-resultChan
+	require.NotNil(t, ev)
+	require.Nil(t, ev.Target)
+	require.NoError(t, ev.Err)
+	_, ok := <-resultChan
+	require.False(t, ok)
 }
 
 func (s *StepRunnerSuite) TestRunningStep() {
@@ -74,27 +85,20 @@ func (s *StepRunnerSuite) TestRunningStep() {
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), resultChan)
 
-	require.NoError(s.T(), addTarget(tgt("TSucc")))
+	require.NoError(s.T(), addTarget(ctx, tgt("TSucc")))
 	ev, ok := <-resultChan
 	require.True(s.T(), ok)
 	require.Equal(s.T(), tgt("TSucc"), ev.Target)
 	require.NoError(s.T(), ev.Err)
 
-	require.NoError(s.T(), addTarget(tgt("TFail")))
+	require.NoError(s.T(), addTarget(ctx, tgt("TFail")))
 	ev, ok = <-resultChan
 	require.True(s.T(), ok)
 	require.Equal(s.T(), tgt("TFail"), ev.Target)
 	require.Error(s.T(), ev.Err)
 
 	stepRunner.Stop()
-
-	ev, ok = <-resultChan
-	require.True(s.T(), ok)
-	require.Nil(s.T(), ev.Target)
-	require.NoError(s.T(), ev.Err)
-
-	ev, ok = <-resultChan
-	require.False(s.T(), ok)
+	checkStoppedSuccessfully(s.T(), resultChan)
 
 	closedCtx, closedCtxCancel := xcontext.WithCancel(ctx)
 	closedCtxCancel()
@@ -107,4 +111,262 @@ func (s *StepRunnerSuite) TestRunningStep() {
 	require.NoError(s.T(), res.Err)
 
 	require.Equal(s.T(), inputResumeState, obtainedResumeState)
+}
+
+func (s *StepRunnerSuite) TestAddSameTargetSequentiallyTimes() {
+	ctx, cancel := xcontext.WithCancel(logrusctx.NewContext(logger.LevelDebug))
+	defer cancel()
+
+	const inputTargetID = "input_target_id"
+
+	err := s.RegisterStateFullStep(
+		func(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
+			_, err := teststeps.ForEachTarget(stateFullStepName, ctx, ch, func(ctx xcontext.Context, target *target.Target) error {
+				require.NotNil(s.T(), target)
+				require.Equal(s.T(), inputTargetID, target.ID)
+				return nil
+			})
+			require.NoError(s.T(), err)
+			return nil, nil
+		},
+		nil,
+	)
+	require.NoError(s.T(), err)
+
+	emitterFactory := NewTestStepEventsEmitterFactory(s.MemoryStorage.StorageEngineVault, 1, 1, testName, 0)
+	emitter := emitterFactory.New("test_step_label")
+
+	stepRunner := NewStepRunner()
+	require.NotNil(s.T(), stepRunner)
+	defer stepRunner.Stop()
+
+	resultChan, addTarget, err := stepRunner.Run(ctx,
+		s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
+		emitter,
+		nil,
+		nil,
+	)
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), resultChan)
+
+	for i := 0; i < 10; i++ {
+		require.NoError(s.T(), addTarget(ctx, tgt(inputTargetID)))
+		ev := <-resultChan
+		require.NotNil(s.T(), ev)
+		require.NotNil(s.T(), ev.Target)
+		require.Equal(s.T(), inputTargetID, ev.Target.ID)
+		require.NoError(s.T(), ev.Err)
+	}
+	stepRunner.Stop()
+	checkStoppedSuccessfully(s.T(), resultChan)
+}
+
+func (s *StepRunnerSuite) TestAddTargetReturnsErrorIfFailsToInput() {
+	ctx, cancel := xcontext.WithCancel(logrusctx.NewContext(logger.LevelDebug))
+	defer cancel()
+
+	const inputTargetID = "input_target_id"
+
+	hangCh := make(chan struct{})
+	defer func() {
+		select {
+		case <-hangCh:
+		default:
+			close(hangCh)
+		}
+	}()
+	err := s.RegisterStateFullStep(
+		func(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
+			<-hangCh
+			for range ch.In {
+				require.Fail(s.T(), "unexpected input")
+			}
+			return nil, nil
+		},
+		nil,
+	)
+	require.NoError(s.T(), err)
+
+	emitterFactory := NewTestStepEventsEmitterFactory(s.MemoryStorage.StorageEngineVault, 1, 1, testName, 0)
+	emitter := emitterFactory.New("test_step_label")
+
+	stepRunner := NewStepRunner()
+	require.NotNil(s.T(), stepRunner)
+	defer stepRunner.Stop()
+
+	resultChan, addTarget, err := stepRunner.Run(ctx,
+		s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
+		emitter,
+		nil,
+		nil,
+	)
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), resultChan)
+
+	s.Run("input_context_cancelled", func() {
+		cancelCtx, cncl := xcontext.WithCancel(ctx)
+		cncl()
+		require.Error(s.T(), addTarget(cancelCtx, tgt(inputTargetID)))
+	})
+
+	s.Run("sopped_during_input", func() {
+		go func() {
+			<-time.After(time.Millisecond)
+			stepRunner.Stop()
+		}()
+		require.Error(s.T(), addTarget(ctx, tgt(inputTargetID)))
+	})
+
+	close(hangCh)
+	stepRunner.Stop()
+	checkStoppedSuccessfully(s.T(), resultChan)
+}
+
+func (s *StepRunnerSuite) TestStepPanics() {
+	ctx, cancel := xcontext.WithCancel(logrusctx.NewContext(logger.LevelDebug))
+	defer cancel()
+
+	err := s.RegisterStateFullStep(
+		func(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
+			panic("panic")
+		},
+		nil,
+	)
+	require.NoError(s.T(), err)
+
+	stepRunner := NewStepRunner()
+	require.NotNil(s.T(), stepRunner)
+	defer stepRunner.Stop()
+
+	resultChan, addTarget, err := stepRunner.Run(ctx,
+		s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
+		NewTestStepEventsEmitterFactory(
+			s.MemoryStorage.StorageEngineVault,
+			1,
+			1,
+			testName,
+			0,
+		).New("test_step_label"),
+		nil,
+		nil,
+	)
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), resultChan)
+
+	// some of AddTarget may succeed as it takes some time for a step to panic
+	var gotError bool
+	for i := 0; i < 10; i++ {
+		time.Sleep(time.Millisecond)
+		if err := addTarget(ctx, tgt("target-id")); err != nil {
+			gotError = true
+		}
+	}
+	require.True(s.T(), gotError)
+
+	ev := <-resultChan
+	require.NotNil(s.T(), ev)
+	require.Nil(s.T(), ev.Target)
+
+	var expectedErrType *cerrors.ErrTestStepPaniced
+	require.ErrorAs(s.T(), ev.Err, &expectedErrType)
+	_, ok := <-resultChan
+	require.False(s.T(), ok)
+}
+
+func (s *StepRunnerSuite) TestCornerCases() {
+	ctx, cancel := xcontext.WithCancel(logrusctx.NewContext(logger.LevelDebug))
+	defer cancel()
+
+	err := s.RegisterStateFullStep(
+		func(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
+			_, err := teststeps.ForEachTarget(stateFullStepName, ctx, ch, func(ctx xcontext.Context, target *target.Target) error {
+				return fmt.Errorf("should not be called")
+			})
+			return nil, err
+		},
+		nil,
+	)
+	require.NoError(s.T(), err)
+
+	emitterFactory := NewTestStepEventsEmitterFactory(s.MemoryStorage.StorageEngineVault, 1, 1, testName, 0)
+	emitter := emitterFactory.New("test_step_label")
+
+	s.Run("add_target_after_stop", func() {
+		stepRunner := NewStepRunner()
+		require.NotNil(s.T(), stepRunner)
+		defer stepRunner.Stop()
+
+		resultChan, addTarget, err := stepRunner.Run(ctx,
+			s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
+			emitter,
+			nil,
+			nil,
+		)
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), resultChan)
+
+		stepRunner.Stop()
+		require.Error(s.T(), addTarget(ctx, tgt("dummy_target")))
+		checkStoppedSuccessfully(s.T(), resultChan)
+	})
+
+	s.Run("run_twice", func() {
+		stepRunner := NewStepRunner()
+		require.NotNil(s.T(), stepRunner)
+		defer stepRunner.Stop()
+
+		resultChan, _, err := stepRunner.Run(ctx,
+			s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
+			emitter,
+			nil,
+			nil,
+		)
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), resultChan)
+
+		resultChan2, _, err2 := stepRunner.Run(ctx,
+			s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
+			emitter,
+			nil,
+			nil,
+		)
+		require.Error(s.T(), err2)
+		require.Nil(s.T(), resultChan2)
+	})
+
+	s.Run("stop_twice", func() {
+		stepRunner := NewStepRunner()
+		require.NotNil(s.T(), stepRunner)
+		defer stepRunner.Stop()
+
+		resultChan, _, err := stepRunner.Run(ctx,
+			s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
+			emitter,
+			nil,
+			nil,
+		)
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), resultChan)
+
+		stepRunner.Stop()
+		stepRunner.Stop()
+		checkStoppedSuccessfully(s.T(), resultChan)
+	})
+
+	s.Run("stop_before_run", func() {
+		stepRunner := NewStepRunner()
+		require.NotNil(s.T(), stepRunner)
+		defer stepRunner.Stop()
+
+		stepRunner.Stop()
+		resultChan, _, err := stepRunner.Run(ctx,
+			s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
+			emitter,
+			nil,
+			nil,
+		)
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), resultChan)
+		checkStoppedSuccessfully(s.T(), resultChan)
+	})
 }

--- a/pkg/runner/step_runner_test.go
+++ b/pkg/runner/step_runner_test.go
@@ -254,20 +254,20 @@ func (s *StepRunnerSuite) TestStepPanics() {
 	require.NotNil(s.T(), resultChan)
 
 	// some of AddTarget may succeed as it takes some time for a step to panic
-	var gotError bool
+	var gotError error
 	for i := 0; i < 10; i++ {
 		time.Sleep(time.Millisecond)
 		if err := addTarget(ctx, tgt("target-id")); err != nil {
-			gotError = true
+			gotError = err
 		}
 	}
-	require.True(s.T(), gotError)
+	var expectedErrType *cerrors.ErrTestStepPaniced
+	require.ErrorAs(s.T(), gotError, &expectedErrType)
 
 	ev := <-resultChan
 	require.NotNil(s.T(), ev)
 	require.Nil(s.T(), ev.Target)
 
-	var expectedErrType *cerrors.ErrTestStepPaniced
 	require.ErrorAs(s.T(), ev.Err, &expectedErrType)
 	_, ok := <-resultChan
 	require.False(s.T(), ok)

--- a/pkg/runner/step_runner_test.go
+++ b/pkg/runner/step_runner_test.go
@@ -65,7 +65,12 @@ func (s *StepRunnerSuite) TestRunningStep() {
 	emitter := emitterFactory.New("test_step_label")
 
 	inputResumeState := json.RawMessage("{\"some_input\": 42}")
-	resultChan, err := stepRunner.Run(ctx, s.NewStep(ctx, "test_step_label", stateFullStepName, nil), emitter, inputResumeState)
+	resultChan, err := stepRunner.Run(ctx,
+		s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
+		emitter,
+		inputResumeState,
+		nil,
+	)
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), resultChan)
 

--- a/pkg/runner/step_runner_test.go
+++ b/pkg/runner/step_runner_test.go
@@ -65,7 +65,7 @@ func (s *StepRunnerSuite) TestRunningStep() {
 	emitter := emitterFactory.New("test_step_label")
 
 	inputResumeState := json.RawMessage("{\"some_input\": 42}")
-	resultChan, err := stepRunner.Run(ctx,
+	resultChan, addTarget, err := stepRunner.Run(ctx,
 		s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
 		emitter,
 		inputResumeState,
@@ -74,13 +74,13 @@ func (s *StepRunnerSuite) TestRunningStep() {
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), resultChan)
 
-	require.NoError(s.T(), stepRunner.AddTarget(ctx, tgt("TSucc")))
+	require.NoError(s.T(), addTarget(tgt("TSucc")))
 	ev, ok := <-resultChan
 	require.True(s.T(), ok)
 	require.Equal(s.T(), tgt("TSucc"), ev.Target)
 	require.NoError(s.T(), ev.Err)
 
-	require.NoError(s.T(), stepRunner.AddTarget(ctx, tgt("TFail")))
+	require.NoError(s.T(), addTarget(tgt("TFail")))
 	ev, ok = <-resultChan
 	require.True(s.T(), ok)
 	require.Equal(s.T(), tgt("TFail"), ev.Target)

--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -202,13 +202,10 @@ func (tr *TestRunner) Run(
 		tgs.handlerRunning = true
 		tr.targetsWg.Add(1)
 
-		// goroutine captures variable by reference -> to avoid race condition we assign the value
-		// of the loop variable to an intermediate variable
-		state := tgs
-		go func() {
+		go func(state *targetState) {
 			tr.targetHandler(targetsCtx, state)
 			tr.targetsWg.Done()
-		}()
+		}(tgs)
 	}
 
 	// Run until no more progress can be made.

--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -360,7 +360,7 @@ func (tr *TestRunner) injectTarget(ctx xcontext.Context, tgs *targetState, ss *s
 	ctx.Debugf("%s: injecting into %s", tgs, ss)
 
 	tgt := tgs.tgt
-	err := ss.addTarget(tgt)
+	err := ss.addTarget(ctx, tgt)
 	if err == nil {
 		tr.mu.Lock()
 		// By the time we get here the target could have been processed and result posted already, hence the check.


### PR DESCRIPTION
Check for ErrTestStepReturnedUnexpectedResult in StepRunner

Fixes:
https://github.com/linuxboot/contest/issues/60
https://github.com/linuxboot/contest/issues/61
https://github.com/linuxboot/contest/issues/66