### PR TITLE
plugins/echo: Expand text parameter and fix number of output vars

### DIFF
--- a/plugins/teststeps/echo/echo.go
+++ b/plugins/teststeps/echo/echo.go
@@ -58,10 +58,14 @@ func (e Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.Te
 			if !ok {
 				return nil, nil
 			}
+			output, err := params.GetOne("text").Expand(target)
+			if err != nil {
+				return nil, err
+			}
 			// guaranteed to work here
 			jobID, _ := types.JobIDFromContext(ctx)
 			runID, _ := types.RunIDFromContext(ctx)
-			ctx.Infof("This is job %d, run %d on target %s with text '%s'", jobID, runID, params.GetOne("text"))
+			ctx.Infof("This is job %d, run %d on target %s with text '%s'", jobID, runID, target.ID, output)
 			ch.Out <- test.TestStepResult{Target: target}
 		case <-ctx.Done():
 			return nil, nil


### PR DESCRIPTION
This plugin is useful to quickly test new user functions (for templates), but it would need to actually run templates for that.

While I was here, I found the number of arguments in the output is wrong, it will always contain a MISSING.