### PR TITLE
Fix on pause race condition in TestRunner

### DIFF
--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -703,13 +703,9 @@ tgtLoop:
 		for _, tgs := range tr.targets {
 			ctx.Debugf("monitor pass %d: %s", pass, tgs)
 			if tgs.handlerRunning && (tgs.CurStep < len(tr.steps) || tgs.CurPhase != targetStepPhaseEnd) {
-				if tgs.CurPhase == targetStepPhaseRun {
-					// We have a target inside a step.
-					ss := tr.steps[tgs.CurStep]
-					if ss.runErr == xcontext.ErrPaused {
-						// It's been paused, this is fine.
-						continue
-					}
+				if tgs.CurPhase == targetStepPhaseRun && tr.steps[tgs.CurStep].runErr == xcontext.ErrPaused {
+					// It's been paused, this is fine.
+					continue
 				}
 				done = false
 				break


### PR DESCRIPTION
When a Paused signal was received, TestRunner cancelled step's context which could prevent correct results processing.

Partially restored logic in runMonitor removed in https://github.com/linuxboot/contest/commit/d952dfa563c451cfbfd31a0ab2eaffd04856064f# 

Fixing: https://github.com/linuxboot/contest/issues/86