### PR TITLE
Add versioning to json test descriptor

### DIFF
--- a/cmds/clients/contestcli/cli/cli.go
+++ b/cmds/clients/contestcli/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/linuxboot/contest/pkg/job"
 	"github.com/linuxboot/contest/pkg/transport/http"
 
 	flag "github.com/spf13/pflag"
@@ -19,6 +20,9 @@ const (
 	defaultRequestor = "contestcli-http"
 	jobWaitPoll      = 10 * time.Second
 )
+
+// JobDescriptorVersion denotes the version that is used by the cli tool
+var JobDescriptorVersion string = job.CurrentDescriptorVersion()
 
 var (
 	flagSet       *flag.FlagSet

--- a/pkg/config/jobdescriptor.go
+++ b/pkg/config/jobdescriptor.go
@@ -21,9 +21,6 @@ const (
 	JobDescFormatYAML
 )
 
-// JobDescriptorVersion denotes the version that is used by the cli tool
-const JobDescriptorVersion string = "1.0"
-
 // ParseJobDescriptor validates a job descriptor's well-formedness, and returns a
 // JSON-formatted descriptor if it was provided in a different format.
 // The currently supported format are JSON and YAML.
@@ -41,10 +38,7 @@ func ParseJobDescriptor(data []byte, jobDescFormat JobDescFormat) ([]byte, error
 			return nil, fmt.Errorf("failed to parse YAML job descriptor: %w", err)
 		}
 	}
-	// Add the Descriptor version if it is not provided
-	if _, ok := jobDesc["Version"]; !ok {
-		jobDesc["Version"] = JobDescriptorVersion
-	}
+
 	// then marshal the structure back to JSON
 	jobDescJSON, err := json.MarshalIndent(jobDesc, "", "    ")
 	if err != nil {

--- a/pkg/config/jobdescriptor.go
+++ b/pkg/config/jobdescriptor.go
@@ -21,6 +21,9 @@ const (
 	JobDescFormatYAML
 )
 
+// JobDescriptorVersion denotes the version that is used by the cli tool
+const JobDescriptorVersion string = "1.0"
+
 // ParseJobDescriptor validates a job descriptor's well-formedness, and returns a
 // JSON-formatted descriptor if it was provided in a different format.
 // The currently supported format are JSON and YAML.
@@ -37,6 +40,10 @@ func ParseJobDescriptor(data []byte, jobDescFormat JobDescFormat) ([]byte, error
 		if err := yaml.Unmarshal(data, &jobDesc); err != nil {
 			return nil, fmt.Errorf("failed to parse YAML job descriptor: %w", err)
 		}
+	}
+	// Add the Descriptor version if it is not provided
+	if _, ok := jobDesc["Version"]; !ok {
+		jobDesc["Version"] = JobDescriptorVersion
 	}
 	// then marshal the structure back to JSON
 	jobDescJSON, err := json.MarshalIndent(jobDesc, "", "    ")

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -67,6 +67,7 @@ func (d *Descriptor) CheckVersion() error {
 	if d.Version == "" {
 		return fmt.Errorf("Version Error: Empty Job Descriptor Version Field!")
 	}
+	// Convert the version string into 2 numbers
 	versionNums := strings.Split(d.Version, ".")
 	if len(versionNums) != 2 {
 		return fmt.Errorf("Version Error: Incorrect Job Descriptor Version %v", d.Version)
@@ -84,6 +85,9 @@ func (d *Descriptor) CheckVersion() error {
 	Currentmajor, _ := strconv.Atoi(currentVersionNums[0])
 	Currentminor, _ := strconv.Atoi(currentVersionNums[1])
 
+	// checks the major,minor numbers againest the supported version
+	// If the major don't match of the minor is ahead of the currently supported
+	// , return an error msg
 	if majorVersion != Currentmajor || minorVersion > Currentminor {
 		return fmt.Errorf(
 			"Version Error: The Job Descriptor Version %s is't compatible with the Server's %s",

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -18,10 +18,11 @@ import (
 	"github.com/insomniacslk/xjson"
 )
 
-// CurrentDescriptorVersion is the current version of the job descriptor
-// that the client must speaks to descripe jobs.
-// It has to number to denote breaking and non-breaking changes
-const CurrentDescriptorVersion string = "1.0"
+// JobDescriptorMajorVersion, JobDescriptorMinorVersion are the current
+// version of the job descriptor that the client must speaks to descripe jobs.
+// It has two numbers to denote breaking and non-breaking changes
+const JobDescriptorMajorVersion uint = 1
+const JobDescriptorMinorVersion uint = 0
 
 // Descriptor models the deserialized version of the JSON text given as
 // input to the job creation request.
@@ -81,22 +82,25 @@ func (d *Descriptor) CheckVersion() error {
 		return fmt.Errorf("Version Error: %w", err)
 	}
 
-	currentVersionNums := strings.Split(CurrentDescriptorVersion, ".")
-	Currentmajor, _ := strconv.Atoi(currentVersionNums[0])
-	Currentminor, _ := strconv.Atoi(currentVersionNums[1])
-
-	// checks the major,minor numbers againest the supported version
+	// checks the major, minor numbers against the supported version
 	// If the major don't match of the minor is ahead of the currently supported
 	// , return an error msg
-	if majorVersion != Currentmajor || minorVersion > Currentminor {
+	if majorVersion != int(JobDescriptorMajorVersion) || minorVersion > int(JobDescriptorMinorVersion) {
 		return fmt.Errorf(
-			"Version Error: The Job Descriptor Version %s is't compatible with the Server's %s",
+			"Version Error: The Job Descriptor Version %s is not compatible with the server: %d.%d",
 			d.Version,
-			CurrentDescriptorVersion,
+			JobDescriptorMajorVersion,
+			JobDescriptorMinorVersion,
 		)
 	}
 
 	return nil
+}
+
+// CurrentDescriptorVersion returns current JobDescriptor version as a string
+// e.g "1.0"
+func CurrentDescriptorVersion() string {
+	return fmt.Sprintf("%d.%d", JobDescriptorMajorVersion, JobDescriptorMinorVersion)
 }
 
 // ExtendedDescriptor is a job descriptor which has been extended with the full

--- a/pkg/job/job_test.go
+++ b/pkg/job/job_test.go
@@ -36,7 +36,7 @@ func TestEmptyVersion(t *testing.T) {
 	)
 }
 
-func TestIncompitableVersions(t *testing.T) {
+func TestIncompatibleVersions(t *testing.T) {
 	var cases []Case
 
 	cases = append(cases, Case{

--- a/pkg/job/job_test.go
+++ b/pkg/job/job_test.go
@@ -1,0 +1,71 @@
+package job
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidVersion(t *testing.T) {
+	validJd := Descriptor{
+		Version: "1.0",
+	}
+
+	require.NoError(t, validJd.CheckVersion())
+}
+
+func TestEmptyVersion(t *testing.T) {
+	emptyVersionJd := Descriptor{
+		Version: "",
+	}
+
+	require.EqualError(
+		t,
+		emptyVersionJd.CheckVersion(),
+		"Version Error: Empty Job Descriptor Version Field!",
+	)
+}
+
+func TestInCompitableVersions(t *testing.T) {
+	// CurrentVersion "1.0"
+	cases := []struct {
+		version        string
+		expectedErrMsg string
+	}{
+		{"1.1", "Version Error: The Job Descriptor Version 1.1 is't compatible with the Server's 1.0"},
+		{"2.0", "Version Error: The Job Descriptor Version 2.0 is't compatible with the Server's 1.0"},
+	}
+
+	for _, c := range cases {
+		require.EqualError(
+			t,
+			(&Descriptor{Version: c.version}).CheckVersion(),
+			c.expectedErrMsg,
+		)
+	}
+
+}
+
+func TestInValidVersion(t *testing.T) {
+	// CurrentVersion "1.0"
+	cases := []struct {
+		version        string
+		expectedErrMsg string
+	}{
+		{"1.", "Version Error: strconv.Atoi: parsing \"\": invalid syntax"},
+		{".0", "Version Error: strconv.Atoi: parsing \"\": invalid syntax"},
+		{".", "Version Error: strconv.Atoi: parsing \"\": invalid syntax"},
+		{"1.a", "Version Error: strconv.Atoi: parsing \"a\": invalid syntax"},
+		{"a.0", "Version Error: strconv.Atoi: parsing \"a\": invalid syntax"},
+		{"123", "Version Error: Incorrect Job Descriptor Version 123"},
+		{"abc", "Version Error: Incorrect Job Descriptor Version abc"},
+	}
+
+	for _, c := range cases {
+		require.EqualError(
+			t,
+			(&Descriptor{Version: c.version}).CheckVersion(),
+			c.expectedErrMsg,
+		)
+	}
+}

--- a/pkg/job/job_test.go
+++ b/pkg/job/job_test.go
@@ -17,11 +17,11 @@ type Case struct {
 }
 
 func TestValidVersion(t *testing.T) {
-	vaild := Descriptor{
+	valid := Descriptor{
 		Version: currentDescriptorVersion,
 	}
 
-	require.NoError(t, vaild.CheckVersion())
+	require.NoError(t, valid.CheckVersion())
 }
 
 func TestEmptyVersion(t *testing.T) {

--- a/pkg/jobmanager/start.go
+++ b/pkg/jobmanager/start.go
@@ -22,6 +22,10 @@ func (jm *JobManager) start(ev *api.Event) *api.EventResponse {
 	if err := json.Unmarshal([]byte(msg.JobDescriptor), &jd); err != nil {
 		return &api.EventResponse{Err: err}
 	}
+	// Check the compatibility of the JobDescriptor
+	if err := jd.CheckVersion(); err != nil {
+		return &api.EventResponse{Err: err}
+	}
 	if err := job.CheckTags(jd.Tags, false /* allowInternal */); err != nil {
 		return &api.EventResponse{Err: err}
 	}

--- a/tests/integ/migration/common.go
+++ b/tests/integ/migration/common.go
@@ -3,6 +3,7 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
+//go:build integration_storage
 // +build integration_storage
 
 package test
@@ -10,11 +11,15 @@ package test
 import (
 	"bytes"
 	"text/template"
+
+	"github.com/linuxboot/contest/pkg/job"
 )
 
+var jobDescriptorVersion = job.CurrentDescriptorVersion()
 var jobDescriptorTemplate = template.Must(template.New("jobDescriptor").Parse(`
 {
     "JobName": "test job",
+    "Version": "{{ .Version }}",
     "Reporting": {
         "FinalReporters": [
             {
@@ -52,18 +57,22 @@ var jobDescriptorTemplate = template.Must(template.New("jobDescriptor").Parse(`
             "TargetManagerName": "TargetList",
             "TargetManagerReleaseParameters": {},
             "TestFetcherFetchParameters": {
-                "Steps": [ {{ . }} ],
+                "Steps": [ {{ .Steps }} ],
                 "TestName": "Literal test"
             },
             "TestFetcherName": "literal"
         }
     ]
-} 
-`))
+}`))
 
 var testSerializedTemplate = template.Must(template.New("testSerialized").Parse(`[[ {{ . }} ]]`))
 
-func descriptorMust(data string) string {
+type templateData struct {
+	Steps   string
+	Version string
+}
+
+func descriptorMust(data *templateData) string {
 	var buf bytes.Buffer
 	if err := jobDescriptorTemplate.Execute(&buf, data); err != nil {
 		panic(err)
@@ -94,5 +103,5 @@ var steps = `
 }
 `
 
-var jobDescriptor = descriptorMust(steps)
+var jobDescriptor = descriptorMust(&templateData{Steps: steps, Version: jobDescriptorVersion})
 var testSerialized = testSerializedMust(steps)


### PR DESCRIPTION
In this merge request, I added the version field to the job descriptor , so that the server can check that it runs jobs that can understand. The check is done before the start of the job by calling `CheckVersion` on the job descriptor. This resolves #20.