### PR TITLE
StepRunner: return ResultNotifier in AddTargetToStep function

### DIFF
--- a/pkg/runner/step_runner.go
+++ b/pkg/runner/step_runner.go
@@ -264,8 +264,8 @@ func (sr *StepRunner) WaitResults(ctx context.Context) (stepResult StepResult, e
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
 	return StepResult{
-		Err:         resultErr,
-		ResumeState: resultResumeState,
+		Err:         sr.resultErr,
+		ResumeState: sr.resultResumeState,
 	}, nil
 }
 

--- a/pkg/runner/step_runner.go
+++ b/pkg/runner/step_runner.go
@@ -16,14 +16,11 @@ import (
 	"github.com/linuxboot/contest/pkg/xcontext"
 )
 
-type AddTargetToStep func(ctx xcontext.Context, tgt *target.Target) error
-
-type StepRunnerEvent struct {
-	// Target if set represents the target for which event was generated
-	Target *target.Target
-	// Err if Target is not nil refers to this Target result otherwise is execution error
-	Err error
+type ResultNotifier interface {
+	ResultCh() <-chan error
 }
+
+type AddTargetToStep func(ctx xcontext.Context, tgt *target.Target) (ResultNotifier, error)
 
 type StepResult struct {
 	Err         error
@@ -37,18 +34,38 @@ type StepRunner struct {
 	inputWg       sync.WaitGroup
 	activeTargets map[string]*stepTargetInfo
 
+	started           bool
 	stopped           chan struct{}
 	finishedCh        chan struct{}
-	resultsChan       chan<- StepRunnerEvent
 	runningLoopActive bool
+	notifyStopped     *resultNotifier
 
 	resultErr         error
 	resultResumeState json.RawMessage
-	notifyStopped     func(err error)
+}
+
+type resultNotifier struct {
+	resultCh chan error
+}
+
+func newResultNotifier() *resultNotifier {
+	return &resultNotifier{
+		resultCh: make(chan error, 1),
+	}
+}
+
+func (str *resultNotifier) ResultCh() <-chan error {
+	return str.resultCh
+}
+
+func (str *resultNotifier) addResult(err error) {
+	str.resultCh <- err
+	close(str.resultCh)
 }
 
 type stepTargetInfo struct {
 	targetInEmitted bool
+	result          *resultNotifier
 }
 
 func (sti *stepTargetInfo) acquireTargetInEmission() bool {
@@ -64,6 +81,7 @@ func NewStepRunner() *StepRunner {
 	return &StepRunner{
 		input:         make(chan *target.Target),
 		activeTargets: make(map[string]*stepTargetInfo),
+		notifyStopped: newResultNotifier(),
 		stopped:       make(chan struct{}),
 		finishedCh:    make(chan struct{}),
 	}
@@ -75,31 +93,22 @@ func (sr *StepRunner) Run(
 	ev testevent.Emitter,
 	resumeState json.RawMessage,
 	resumeStateTargets []target.Target,
-) (<-chan StepRunnerEvent, AddTargetToStep, error) {
+) (AddTargetToStep, []ResultNotifier, ResultNotifier, error) {
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
 
-	if sr.resultsChan != nil {
-		return nil, nil, &cerrors.ErrAlreadyDone{}
+	if sr.started {
+		return nil, nil, nil, &cerrors.ErrAlreadyDone{}
 	}
 
-	var notifyStoppedOnce sync.Once
-	sr.notifyStopped = func(err error) {
-		notifyStoppedOnce.Do(func() {
-			select {
-			case sr.resultsChan <- StepRunnerEvent{Err: err}:
-			case <-ctx.Done():
-			}
-		})
-	}
-
-	resultsChan := make(chan StepRunnerEvent, 1)
-	sr.resultsChan = resultsChan
-
+	var resumedTargetsResults []ResultNotifier
 	for _, resumeTarget := range resumeStateTargets {
-		sr.activeTargets[resumeTarget.ID] = &stepTargetInfo{
+		targetInfo := &stepTargetInfo{
 			targetInEmitted: true,
+			result:          newResultNotifier(),
 		}
+		sr.activeTargets[resumeTarget.ID] = targetInfo
+		resumedTargetsResults = append(resumedTargetsResults, targetInfo.result)
 	}
 
 	var activeLoopsCount int32 = 2
@@ -110,13 +119,13 @@ func (sr *StepRunner) Run(
 
 		sr.mu.Lock()
 		close(sr.finishedCh)
+		// if an error occurred we already sent notification
+		if sr.resultErr == nil {
+			sr.notifyStopped.addResult(nil)
+		}
 		sr.mu.Unlock()
 
-		// if an error occurred we already sent notification
-		sr.notifyStopped(nil)
-		close(sr.resultsChan)
 		ctx.Debugf("StepRunner finished")
-
 		sr.Stop()
 	}
 
@@ -133,9 +142,10 @@ func (sr *StepRunner) Run(
 		ctx.Debugf("Reading loop finished")
 	}()
 
-	return resultsChan, func(ctx xcontext.Context, tgt *target.Target) error {
+	sr.started = true
+	return func(ctx xcontext.Context, tgt *target.Target) (ResultNotifier, error) {
 		return sr.addTarget(ctx, bundle, ev, tgt)
-	}, nil
+	}, resumedTargetsResults, sr.notifyStopped, nil
 }
 
 func (sr *StepRunner) addTarget(
@@ -143,9 +153,9 @@ func (sr *StepRunner) addTarget(
 	bundle test.TestStepBundle,
 	ev testevent.Emitter,
 	tgt *target.Target,
-) error {
+) (ResultNotifier, error) {
 	if tgt == nil {
-		return fmt.Errorf("target should not be nil")
+		return nil, fmt.Errorf("target should not be nil")
 	}
 
 	sr.mu.Lock()
@@ -153,27 +163,28 @@ func (sr *StepRunner) addTarget(
 	sr.mu.Unlock()
 	if stopped == nil {
 		if err := sr.getErr(); err != nil {
-			return err
+			return nil, err
 		}
-		return fmt.Errorf("step runner was stopped")
+		return nil, fmt.Errorf("step runner was stopped")
 	}
 
-	err := func() error {
+	targetInfo, err := func() (*stepTargetInfo, error) {
 		targetInfo, err := func() (*stepTargetInfo, error) {
 			sr.mu.Lock()
 			defer sr.mu.Unlock()
 
 			if targetInfo := sr.activeTargets[tgt.ID]; targetInfo != nil {
-				return nil, fmt.Errorf("target is already processed")
+				return nil, fmt.Errorf("target is already added")
 			}
-			targetInfo := &stepTargetInfo{}
+			targetInfo := &stepTargetInfo{
+				result: newResultNotifier(),
+			}
 			sr.activeTargets[tgt.ID] = targetInfo
 			sr.inputWg.Add(1)
 			return targetInfo, nil
 		}()
-
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		defer sr.inputWg.Done()
@@ -189,13 +200,13 @@ func (sr *StepRunner) addTarget(
 				}
 			}
 			sr.mu.Unlock()
-			return nil
+			return targetInfo, nil
 		case <-stopped:
-			return fmt.Errorf("step runner was stopped")
+			return nil, fmt.Errorf("step runner was stopped")
 		case <-ctx.Until(xcontext.ErrPaused):
-			return xcontext.ErrPaused
+			return nil, xcontext.ErrPaused
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil, ctx.Err()
 		}
 	}()
 
@@ -210,16 +221,16 @@ func (sr *StepRunner) addTarget(
 			err = sr.resultErr
 		}
 		sr.mu.Unlock()
-		return err
+		return nil, err
 	}
-	return nil
+	return targetInfo.result, nil
 }
 
 func (sr *StepRunner) Started() bool {
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
 
-	return sr.resultsChan != nil
+	return sr.started
 }
 
 // WaitResults returns TestStep.Run() output
@@ -316,24 +327,24 @@ func (sr *StepRunner) outputLoop(
 			}
 			ctx.Infof("Obtained '%v' for target '%s'", res, res.Target.ID)
 
-			shouldEmitTargetIn, err := func() (bool, error) {
+			shouldEmitTargetIn, targetResult, err := func() (bool, *resultNotifier, error) {
 				sr.mu.Lock()
 				defer sr.mu.Unlock()
 
 				info, found := sr.activeTargets[res.Target.ID]
 				if !found {
-					return false, &cerrors.ErrTestStepReturnedUnexpectedResult{
+					return false, nil, &cerrors.ErrTestStepReturnedUnexpectedResult{
 						StepName: testStepLabel,
 						Target:   res.Target.ID,
 					}
 				}
 				if info == nil {
-					return false, &cerrors.ErrTestStepReturnedDuplicateResult{StepName: testStepLabel, Target: res.Target.ID}
+					return false, nil, &cerrors.ErrTestStepReturnedDuplicateResult{StepName: testStepLabel, Target: res.Target.ID}
 				}
 				sr.activeTargets[res.Target.ID] = nil
 
 				shouldEmitTargetIn := info.acquireTargetInEmission()
-				return shouldEmitTargetIn, nil
+				return shouldEmitTargetIn, info.result, nil
 			}()
 			if err != nil {
 				sr.setErr(ctx, err)
@@ -357,16 +368,7 @@ func (sr *StepRunner) outputLoop(
 				sr.setErr(ctx, err)
 				return
 			}
-
-			select {
-			case sr.resultsChan <- StepRunnerEvent{Target: res.Target, Err: res.Err}:
-			case <-ctx.Done():
-				ctx.Debugf(
-					"reading loop detected context canceled, target '%s' with result: '%v' was not reported",
-					res.Target.ID,
-					res.Err,
-				)
-			}
+			targetResult.addResult(res.Err)
 		case <-ctx.Done():
 			ctx.Debugf("IO loop detected context canceled")
 			return
@@ -432,10 +434,7 @@ func (sr *StepRunner) setErrLocked(ctx xcontext.Context, err error) {
 	ctx.Errorf("err: %v", err)
 	sr.resultErr = err
 
-	// notifyStopped is a blocking operation: should release the lock
-	sr.mu.Unlock()
-	sr.notifyStopped(err)
-	sr.mu.Lock()
+	sr.notifyStopped.addResult(err)
 }
 
 func (sr *StepRunner) getErr() error {

--- a/pkg/runner/step_runner_test.go
+++ b/pkg/runner/step_runner_test.go
@@ -27,12 +27,19 @@ type StepRunnerSuite struct {
 	BaseTestSuite
 }
 
-func checkStoppedSuccessfully(t *testing.T, resultChan <-chan StepRunnerEvent) {
-	ev := <-resultChan
-	require.NotNil(t, ev)
-	require.Nil(t, ev.Target)
-	require.NoError(t, ev.Err)
-	_, ok := <-resultChan
+func checkSuccessfulResult(t *testing.T, result ResultNotifier) {
+	err, ok := <-result.ResultCh()
+	require.True(t, ok)
+	require.NoError(t, err)
+	_, ok = <-result.ResultCh()
+	require.False(t, ok)
+}
+
+func checkErrorResult(t *testing.T, result ResultNotifier) {
+	err, ok := <-result.ResultCh()
+	require.True(t, ok)
+	require.Error(t, err)
+	_, ok = <-result.ResultCh()
 	require.False(t, ok)
 }
 
@@ -76,29 +83,29 @@ func (s *StepRunnerSuite) TestRunningStep() {
 	emitter := emitterFactory.New("test_step_label")
 
 	inputResumeState := json.RawMessage("{\"some_input\": 42}")
-	resultChan, addTarget, err := stepRunner.Run(ctx,
+	addTarget, resumedTargetsResults, runResult, err := stepRunner.Run(ctx,
 		s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
 		emitter,
 		inputResumeState,
 		nil,
 	)
 	require.NoError(s.T(), err)
-	require.NotNil(s.T(), resultChan)
+	require.NotNil(s.T(), addTarget)
+	require.Empty(s.T(), resumedTargetsResults)
+	require.NotNil(s.T(), runResult)
 
-	require.NoError(s.T(), addTarget(ctx, tgt("TSucc")))
-	ev, ok := <-resultChan
-	require.True(s.T(), ok)
-	require.Equal(s.T(), tgt("TSucc"), ev.Target)
-	require.NoError(s.T(), ev.Err)
+	tgtResult, err := addTarget(ctx, tgt("TSucc"))
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), tgtResult)
+	checkSuccessfulResult(s.T(), tgtResult)
 
-	require.NoError(s.T(), addTarget(ctx, tgt("TFail")))
-	ev, ok = <-resultChan
-	require.True(s.T(), ok)
-	require.Equal(s.T(), tgt("TFail"), ev.Target)
-	require.Error(s.T(), ev.Err)
+	tgtResult, err = addTarget(ctx, tgt("TFail"))
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), tgtResult)
+	checkErrorResult(s.T(), tgtResult)
 
 	stepRunner.Stop()
-	checkStoppedSuccessfully(s.T(), resultChan)
+	checkSuccessfulResult(s.T(), runResult)
 
 	closedCtx, closedCtxCancel := xcontext.WithCancel(ctx)
 	closedCtxCancel()
@@ -140,25 +147,22 @@ func (s *StepRunnerSuite) TestAddSameTargetSequentiallyTimes() {
 	require.NotNil(s.T(), stepRunner)
 	defer stepRunner.Stop()
 
-	resultChan, addTarget, err := stepRunner.Run(ctx,
+	addTarget, _, runResult, err := stepRunner.Run(ctx,
 		s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
 		emitter,
 		nil,
 		nil,
 	)
 	require.NoError(s.T(), err)
-	require.NotNil(s.T(), resultChan)
+	require.NotNil(s.T(), runResult)
 
 	for i := 0; i < 10; i++ {
-		require.NoError(s.T(), addTarget(ctx, tgt(inputTargetID)))
-		ev := <-resultChan
-		require.NotNil(s.T(), ev)
-		require.NotNil(s.T(), ev.Target)
-		require.Equal(s.T(), inputTargetID, ev.Target.ID)
-		require.NoError(s.T(), ev.Err)
+		tgtResult, err := addTarget(ctx, tgt(inputTargetID))
+		require.NoError(s.T(), err)
+		checkSuccessfulResult(s.T(), tgtResult)
 	}
 	stepRunner.Stop()
-	checkStoppedSuccessfully(s.T(), resultChan)
+	checkSuccessfulResult(s.T(), runResult)
 }
 
 func (s *StepRunnerSuite) TestAddTargetReturnsErrorIfFailsToInput() {
@@ -194,19 +198,24 @@ func (s *StepRunnerSuite) TestAddTargetReturnsErrorIfFailsToInput() {
 	require.NotNil(s.T(), stepRunner)
 	defer stepRunner.Stop()
 
-	resultChan, addTarget, err := stepRunner.Run(ctx,
+	addTarget, resumedTargetsResults, runResult, err := stepRunner.Run(ctx,
 		s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
 		emitter,
 		nil,
 		nil,
 	)
 	require.NoError(s.T(), err)
-	require.NotNil(s.T(), resultChan)
+	require.NotNil(s.T(), addTarget)
+	require.Empty(s.T(), resumedTargetsResults)
+	require.NotNil(s.T(), runResult)
 
 	s.Run("input_context_cancelled", func() {
 		cancelCtx, cncl := xcontext.WithCancel(ctx)
 		cncl()
-		require.Error(s.T(), addTarget(cancelCtx, tgt(inputTargetID)))
+
+		tgtResult, err := addTarget(cancelCtx, tgt(inputTargetID))
+		require.Error(s.T(), err)
+		require.Nil(s.T(), tgtResult)
 	})
 
 	s.Run("sopped_during_input", func() {
@@ -214,12 +223,14 @@ func (s *StepRunnerSuite) TestAddTargetReturnsErrorIfFailsToInput() {
 			<-time.After(time.Millisecond)
 			stepRunner.Stop()
 		}()
-		require.Error(s.T(), addTarget(ctx, tgt(inputTargetID)))
+		tgtResult, err := addTarget(ctx, tgt(inputTargetID))
+		require.Error(s.T(), err)
+		require.Nil(s.T(), tgtResult)
 	})
 
 	close(hangCh)
 	stepRunner.Stop()
-	checkStoppedSuccessfully(s.T(), resultChan)
+	checkSuccessfulResult(s.T(), runResult)
 }
 
 func (s *StepRunnerSuite) TestStepPanics() {
@@ -238,7 +249,7 @@ func (s *StepRunnerSuite) TestStepPanics() {
 	require.NotNil(s.T(), stepRunner)
 	defer stepRunner.Stop()
 
-	resultChan, addTarget, err := stepRunner.Run(ctx,
+	addTarget, resumedTargetsResults, runResult, err := stepRunner.Run(ctx,
 		s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
 		NewTestStepEventsEmitterFactory(
 			s.MemoryStorage.StorageEngineVault,
@@ -251,25 +262,24 @@ func (s *StepRunnerSuite) TestStepPanics() {
 		nil,
 	)
 	require.NoError(s.T(), err)
-	require.NotNil(s.T(), resultChan)
+	require.NotNil(s.T(), addTarget)
+	require.Empty(s.T(), resumedTargetsResults)
+	require.NotNil(s.T(), runResult)
 
 	// some of AddTarget may succeed as it takes some time for a step to panic
 	var gotError error
 	for i := 0; i < 10; i++ {
 		time.Sleep(time.Millisecond)
-		if err := addTarget(ctx, tgt("target-id")); err != nil {
+		if _, err := addTarget(ctx, tgt("target-id")); err != nil {
 			gotError = err
 		}
 	}
 	var expectedErrType *cerrors.ErrTestStepPaniced
 	require.ErrorAs(s.T(), gotError, &expectedErrType)
 
-	ev := <-resultChan
-	require.NotNil(s.T(), ev)
-	require.Nil(s.T(), ev.Target)
-
-	require.ErrorAs(s.T(), ev.Err, &expectedErrType)
-	_, ok := <-resultChan
+	runErr := <-runResult.ResultCh()
+	require.ErrorAs(s.T(), runErr, &expectedErrType)
+	_, ok := <-runResult.ResultCh()
 	require.False(s.T(), ok)
 }
 
@@ -296,18 +306,22 @@ func (s *StepRunnerSuite) TestCornerCases() {
 		require.NotNil(s.T(), stepRunner)
 		defer stepRunner.Stop()
 
-		resultChan, addTarget, err := stepRunner.Run(ctx,
+		addTarget, _, runResult, err := stepRunner.Run(ctx,
 			s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
 			emitter,
 			nil,
 			nil,
 		)
 		require.NoError(s.T(), err)
-		require.NotNil(s.T(), resultChan)
+		require.NotNil(s.T(), addTarget)
+		require.NotNil(s.T(), runResult)
 
 		stepRunner.Stop()
-		require.Error(s.T(), addTarget(ctx, tgt("dummy_target")))
-		checkStoppedSuccessfully(s.T(), resultChan)
+
+		tgtResult, err := addTarget(ctx, tgt("dummy_target"))
+		require.Error(s.T(), err)
+		require.Nil(s.T(), tgtResult)
+		checkSuccessfulResult(s.T(), runResult)
 	})
 
 	s.Run("run_twice", func() {
@@ -315,23 +329,25 @@ func (s *StepRunnerSuite) TestCornerCases() {
 		require.NotNil(s.T(), stepRunner)
 		defer stepRunner.Stop()
 
-		resultChan, _, err := stepRunner.Run(ctx,
+		addTarget, _, runResult, err := stepRunner.Run(ctx,
 			s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
 			emitter,
 			nil,
 			nil,
 		)
 		require.NoError(s.T(), err)
-		require.NotNil(s.T(), resultChan)
+		require.NotNil(s.T(), addTarget)
+		require.NotNil(s.T(), runResult)
 
-		resultChan2, _, err2 := stepRunner.Run(ctx,
+		addTarget2, _, runResult2, err2 := stepRunner.Run(ctx,
 			s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
 			emitter,
 			nil,
 			nil,
 		)
 		require.Error(s.T(), err2)
-		require.Nil(s.T(), resultChan2)
+		require.Nil(s.T(), addTarget2)
+		require.Nil(s.T(), runResult2)
 	})
 
 	s.Run("stop_twice", func() {
@@ -339,18 +355,19 @@ func (s *StepRunnerSuite) TestCornerCases() {
 		require.NotNil(s.T(), stepRunner)
 		defer stepRunner.Stop()
 
-		resultChan, _, err := stepRunner.Run(ctx,
+		addTarget, _, runResult, err := stepRunner.Run(ctx,
 			s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
 			emitter,
 			nil,
 			nil,
 		)
 		require.NoError(s.T(), err)
-		require.NotNil(s.T(), resultChan)
+		require.NotNil(s.T(), addTarget)
+		require.NotNil(s.T(), runResult)
 
 		stepRunner.Stop()
 		stepRunner.Stop()
-		checkStoppedSuccessfully(s.T(), resultChan)
+		checkSuccessfulResult(s.T(), runResult)
 	})
 
 	s.Run("stop_before_run", func() {
@@ -359,14 +376,15 @@ func (s *StepRunnerSuite) TestCornerCases() {
 		defer stepRunner.Stop()
 
 		stepRunner.Stop()
-		resultChan, _, err := stepRunner.Run(ctx,
+		addTarget, _, runResult, err := stepRunner.Run(ctx,
 			s.NewStep(ctx, "test_step_label", stateFullStepName, nil),
 			emitter,
 			nil,
 			nil,
 		)
 		require.NoError(s.T(), err)
-		require.NotNil(s.T(), resultChan)
-		checkStoppedSuccessfully(s.T(), resultChan)
+		require.NotNil(s.T(), addTarget)
+		require.NotNil(s.T(), runResult)
+		checkSuccessfulResult(s.T(), runResult)
 	})
 }

--- a/pkg/runner/step_runner_test.go
+++ b/pkg/runner/step_runner_test.go
@@ -27,19 +27,19 @@ type StepRunnerSuite struct {
 	BaseTestSuite
 }
 
-func checkSuccessfulResult(t *testing.T, result ResultNotifier) {
-	err, ok := <-result.ResultCh()
+func checkSuccessfulResult(t *testing.T, result ChanNotifier) {
+	err, ok := <-result.NotifyCh()
 	require.True(t, ok)
 	require.NoError(t, err)
-	_, ok = <-result.ResultCh()
+	_, ok = <-result.NotifyCh()
 	require.False(t, ok)
 }
 
-func checkErrorResult(t *testing.T, result ResultNotifier) {
-	err, ok := <-result.ResultCh()
+func checkErrorResult(t *testing.T, result ChanNotifier) {
+	err, ok := <-result.NotifyCh()
 	require.True(t, ok)
 	require.Error(t, err)
-	_, ok = <-result.ResultCh()
+	_, ok = <-result.NotifyCh()
 	require.False(t, ok)
 }
 
@@ -277,9 +277,9 @@ func (s *StepRunnerSuite) TestStepPanics() {
 	var expectedErrType *cerrors.ErrTestStepPaniced
 	require.ErrorAs(s.T(), gotError, &expectedErrType)
 
-	runErr := <-runResult.ResultCh()
+	runErr := <-runResult.NotifyCh()
 	require.ErrorAs(s.T(), runErr, &expectedErrType)
-	_, ok := <-runResult.ResultCh()
+	_, ok := <-runResult.NotifyCh()
 	require.False(s.T(), ok)
 }
 


### PR DESCRIPTION
Previously StepRunner reported target results (and self) via channel that aligned with previous code (we stand for small step changes), but was awful in general as it required non-trivial passing results to state machine.

I refactored code such that  AddTargetToStep returns a waitable object that can report result for the added target.
That removed all code regarding to that results passing.

Fixes: https://github.com/linuxboot/contest/issues/74, https://github.com/linuxboot/contest/issues/54

Note:

targetStepPhaseResultPending is now not needed. I kept it for compatibility (iota). In practice it was impossible to get in resume state and has not code for proper restoration, so we face no risk for a breaking change for some paused state.

The ugly test_runner.go became 100 LoCs shorter.
Next step: make stepState as a standalone object that is a helper for integrating StepRunner into TestRunner (as it is right now, but currently it is highly coupled with TestRunner): https://github.com/linuxboot/contest/issues/97. Currently it is really ugly that target processing state machine operates on different "guts" of a stepState