### PR TITLE
feat(xcontext): Allow to disable labels in the prometheus adapter

### DIFF
--- a/pkg/xcontext/metrics/prometheus/metrics_test.go
+++ b/pkg/xcontext/metrics/prometheus/metrics_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/linuxboot/contest/pkg/xcontext/fields"
 	"github.com/linuxboot/contest/pkg/xcontext/metrics"
 	metricstester "github.com/linuxboot/contest/pkg/xcontext/metrics/test"
 	"github.com/prometheus/client_golang/prometheus"
@@ -127,4 +128,14 @@ func TestMergeSortedStrings(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestDisabledLabels(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	var m metrics.Metrics = New(registry, nil, OptionDisableLabels(true))
+	m = m.WithTag("1", 2)
+	c := m.Count("someCount")
+	require.Len(t, c.(*Count).labelNames, 0)
+	c = c.WithOverriddenTags(fields.Fields{"3": 4})
+	require.Len(t, c.(*Count).labelNames, 0)
 }

--- a/pkg/xcontext/metrics/prometheus/option.go
+++ b/pkg/xcontext/metrics/prometheus/option.go
@@ -1,0 +1,29 @@
+package prometheus
+
+// Option is an optional argument to function New, that changes the behavior of the metrics handler.
+type Option interface {
+	apply(*config)
+}
+
+type options []Option
+
+func (s options) Config() config {
+	var cfg config
+	for _, opt := range s {
+		opt.apply(&cfg)
+	}
+	return cfg
+}
+
+type config struct {
+	DisableLabels bool
+}
+
+// OptionDisableLabels disables the labels (tags) and makes all the metrics flat.
+// Attempts to get a metrics with the same key but different tags will result into
+// getting the same metric. And all the metrics will be registered without labels.
+type OptionDisableLabels bool
+
+func (opt OptionDisableLabels) apply(cfg *config) {
+	cfg.DisableLabels = bool(opt)
+}


### PR DESCRIPTION
This is require due to 3 reasons:
* Prometheus does not really support deleting metrics. But in our design we need to dynamically update the possible collection of labels. So we do some unsafe hackery to make that possible. And to disable this behavior one may want to just disable labels.
* Prometheus does not have garbage collection for label values which were not used for a long time. Once a value is used it stays forever without manual intervention. Which creates a memory consumption problem in some applications.
* Somebody may just want to have flat metrics due to reasons not related to prometheus.