### PR TITLE
Add log query endpoint

### DIFF
--- a/cmds/admin_server/main.go
+++ b/cmds/admin_server/main.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 
 	"github.com/linuxboot/contest/cmds/admin_server/server"
-	mongoAdapter "github.com/linuxboot/contest/cmds/admin_server/storage/mongo"
+	mongoStorage "github.com/linuxboot/contest/cmds/admin_server/storage/mongo"
 	"github.com/linuxboot/contest/pkg/logging"
 	"github.com/linuxboot/contest/pkg/xcontext/bundles/logrusctx"
 	"github.com/linuxboot/contest/pkg/xcontext/logger"
@@ -51,7 +51,7 @@ func main() {
 		exitWithError(err, 1)
 	}
 
-	storage, err := mongoAdapter.NewMongoStorage(*flagDBURI)
+	storage, err := mongoStorage.NewMongoStorage(*flagDBURI)
 	if err != nil {
 		exitWithError(err, 1)
 	}

--- a/cmds/admin_server/server/server.go
+++ b/cmds/admin_server/server/server.go
@@ -5,11 +5,65 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/linuxboot/contest/cmds/admin_server/storage"
 	"github.com/linuxboot/contest/pkg/xcontext"
 )
+
+var (
+	MaxPageSize uint = 100
+	DefaultPage uint = 0
+)
+
+type Query struct {
+	Text      *string    `form:"text"`
+	LogLevel  *string    `form:"logLevel"`
+	StartDate *time.Time `form:"startDate" time_format:"2006-01-02T15:04:05.000Z07:00"`
+	EndDate   *time.Time `form:"endDate" time_format:"2006-01-02T15:04:05.000Z07:00"`
+	PageSize  *uint      `form:"pageSize"`
+	Page      *uint      `form:"page"`
+}
+
+// toStorageQurey returns a storage Query and populates the required fields
+func (q *Query) ToStorageQuery() storage.Query {
+	storageQuery := storage.Query{
+		Page:     DefaultPage,
+		PageSize: MaxPageSize,
+	}
+
+	storageQuery.Text = q.Text
+	storageQuery.LogLevel = q.LogLevel
+	storageQuery.StartDate = q.StartDate
+	storageQuery.EndDate = q.EndDate
+
+	if q.Page != nil {
+		storageQuery.Page = *q.Page
+	}
+
+	if q.PageSize != nil && *q.PageSize < MaxPageSize {
+		storageQuery.PageSize = *q.PageSize
+	}
+
+	return storageQuery
+}
+
+type Log struct {
+	JobID    uint64    `json:"jobID"`
+	LogData  string    `json:"logData"`
+	Date     time.Time `json:"date"`
+	LogLevel string    `json:"logLevel"`
+}
+
+func (l *Log) ToStorageLog() storage.Log {
+	return storage.Log{
+		JobID:    l.JobID,
+		LogData:  l.LogData,
+		Date:     l.Date,
+		LogLevel: l.LogLevel,
+	}
+}
 
 type RouteHandler struct {
 	storage storage.Storage
@@ -22,14 +76,14 @@ func (r *RouteHandler) status(c *gin.Context) {
 
 // addLog inserts a new log entry inside the database
 func (r *RouteHandler) addLog(c *gin.Context) {
-	var log storage.Log
+	var log Log
 	if err := c.Bind(&log); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"status": "err", "msg": "bad formatted log"})
+		c.JSON(http.StatusBadRequest, gin.H{"status": "err", "msg": "badly formatted log"})
 		fmt.Fprintf(os.Stderr, "Err while binding request body %v", err)
 		return
 	}
 
-	err := r.storage.StoreLog(log)
+	err := r.storage.StoreLog(log.ToStorageLog())
 	if err != nil {
 		switch {
 		case errors.Is(err, storage.ErrInsert):
@@ -45,6 +99,23 @@ func (r *RouteHandler) addLog(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
+// geLogs gets logs form the db based on the filters
+func (r *RouteHandler) getLogs(c *gin.Context) {
+	var query Query
+	if err := c.BindQuery(&query); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"status": "err", "msg": fmt.Sprintf("bad formatted query %v", err)})
+		return
+	}
+
+	result, err := r.storage.GetLogs(query.ToStorageQuery())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": "err", "msg": "error while getting the logs"})
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
 func initRouter(ctx xcontext.Context, rh RouteHandler) *gin.Engine {
 
 	r := gin.New()
@@ -52,6 +123,7 @@ func initRouter(ctx xcontext.Context, rh RouteHandler) *gin.Engine {
 
 	r.GET("/status", rh.status)
 	r.POST("/log", rh.addLog)
+	r.GET("/log", rh.getLogs)
 
 	return r
 }

--- a/cmds/admin_server/storage/mongo/mongo.go
+++ b/cmds/admin_server/storage/mongo/mongo.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/linuxboot/contest/cmds/admin_server/storage"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -53,15 +56,59 @@ func NewMongoStorage(uri string) (storage.Storage, error) {
 	}, nil
 }
 
-func (s *MongoStorage) StoreLog(log storage.Log) error {
-	logEntry := Log{
-		log,
+func toMongoQuery(query storage.Query) bson.D {
+	q := bson.D{}
+
+	if query.Text != nil {
+		q = append(q, bson.E{
+			Key: "logdata",
+			Value: bson.M{
+				"$regex": primitive.Regex{Pattern: *query.Text, Options: "ig"},
+			},
+		})
 	}
+
+	if query.StartDate != nil && query.EndDate != nil {
+		q = append(q, bson.E{
+			Key: "date",
+			Value: bson.M{
+				"$gte": primitive.NewDateTimeFromTime(*query.StartDate),
+				"$lte": primitive.NewDateTimeFromTime(*query.EndDate),
+			},
+		})
+	} else if query.StartDate != nil {
+		q = append(q, bson.E{
+			Key:   "date",
+			Value: bson.M{"$gte": primitive.NewDateTimeFromTime(*query.StartDate)},
+		})
+	} else if query.EndDate != nil {
+		q = append(q, bson.E{
+			Key:   "date",
+			Value: bson.M{"$lte": primitive.NewDateTimeFromTime(*query.EndDate)},
+		})
+	}
+
+	if query.LogLevel != nil && *query.LogLevel != "" {
+		levels := strings.Split(*query.LogLevel, ",")
+		q = append(q,
+			bson.E{
+				Key: "loglevel",
+				Value: bson.M{
+					"$in": levels,
+				},
+			},
+		)
+	}
+
+	return q
+}
+
+func (s *MongoStorage) StoreLog(log storage.Log) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultConnectionTimeout)
 	defer cancel()
 
-	_, err := s.collection.InsertOne(ctx, logEntry)
+	_, err := s.collection.InsertOne(ctx, log)
 	if err != nil {
 		// for better debugging
 		fmt.Fprintf(os.Stderr, "Error while inserting into the db: %v", err)
@@ -70,15 +117,48 @@ func (s *MongoStorage) StoreLog(log storage.Log) error {
 	return nil
 }
 
-func (s *MongoStorage) GetLogs(query storage.Query) ([]storage.Log, error) {
-	// TODO
-	return nil, nil
+func (s *MongoStorage) GetLogs(query storage.Query) (*storage.Result, error) {
+
+	q := toMongoQuery(query)
+
+	//get the count of the logs
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultConnectionTimeout)
+	defer cancel()
+	count, err := s.collection.CountDocuments(ctx, q)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error while performing count query: %v", err)
+		return nil, storage.ErrQuery
+	}
+
+	opts := options.Find()
+	opts.SetSkip(int64(int(query.PageSize) * int(query.Page)))
+	opts.SetLimit(int64(query.PageSize))
+
+	ctx, cancel = context.WithTimeout(context.Background(), DefaultConnectionTimeout)
+	defer cancel()
+	cur, err := s.collection.Find(ctx, q, opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error while querying logs from db: %v", err)
+		return nil, storage.ErrQuery
+	}
+
+	var logs []storage.Log
+	ctx, cancel = context.WithTimeout(context.Background(), DefaultConnectionTimeout)
+	defer cancel()
+	err = cur.All(ctx, &logs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error while reading query result from db: %v", err)
+		return nil, storage.ErrQuery
+	}
+
+	return &storage.Result{
+		Logs:     logs,
+		Count:    uint64(count),
+		Page:     query.Page,
+		PageSize: query.PageSize,
+	}, nil
 }
 
 func (s *MongoStorage) Close() error {
 	return s.dbClient.Disconnect(context.Background())
-}
-
-type Log struct {
-	storage.Log `json:"log"`
 }

--- a/cmds/admin_server/storage/storage.go
+++ b/cmds/admin_server/storage/storage.go
@@ -8,11 +8,17 @@ import (
 var (
 	ErrReadOnlyStorage = errors.New("error read only storage")
 	ErrInsert          = errors.New("error inserting into the db")
+	ErrConstructQuery  = errors.New("error forming db query from api query")
+	ErrQuery           = errors.New("error querying from the database")
+)
+
+var (
+	DefaultTimestampFormat = "2006-01-02T15:04:05.000Z07:00"
 )
 
 type Storage interface {
 	StoreLog(Log) error
-	GetLogs(Query) ([]Log, error)
+	GetLogs(Query) (*Result, error)
 
 	Close() error
 }
@@ -27,9 +33,18 @@ type Log struct {
 
 // Query defines the different options to filter with
 type Query struct {
-	Text      string
-	LogLevel  string
-	StartDate string
-	EndDate   string
-	Page      int
+	Text      *string
+	LogLevel  *string
+	StartDate *time.Time
+	EndDate   *time.Time
+	PageSize  uint
+	Page      uint
+}
+
+//Result defines the expected result returned from the db
+type Result struct {
+	Logs     []Log  `json:"logs"`
+	Count    uint64 `json:"count"`
+	Page     uint   `json:"page"`
+	PageSize uint   `json:"pageSize"`
 }

--- a/tests/integ/admin_server/flags_test.go
+++ b/tests/integ/admin_server/flags_test.go
@@ -1,0 +1,15 @@
+//go:build integration
+// +build integration
+
+package test
+
+import (
+	"flag"
+	"time"
+)
+
+var (
+	flagAdminEndpoint    = flag.String("adminServer", "http://adminserver:8000/log", "admin server log push endpoint")
+	flagMongoEndpoint    = flag.String("mongoDBURI", "mongodb://mongostorage:27017", "mongodb URI")
+	flagOperationTimeout = flag.Duration("operationTimeout", time.Duration(10*time.Second), "operation timeout duration")
+)

--- a/tests/integ/admin_server/getlogs_test.go
+++ b/tests/integ/admin_server/getlogs_test.go
@@ -1,0 +1,372 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+//go:build integration
+// +build integration
+
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/linuxboot/contest/cmds/admin_server/server"
+	"github.com/linuxboot/contest/cmds/admin_server/storage"
+	mongoStorage "github.com/linuxboot/contest/cmds/admin_server/storage/mongo"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var logLevels = []string{"panic", "fatal", "error", "warning", "info", "debug"}
+
+func randomText() string {
+	rand.Seed(time.Now().UnixNano())
+
+	ran_str := make([]byte, 10)
+
+	for i := 0; i < 10; i++ {
+		ran_str[i] = byte(65 + rand.Intn(25))
+	}
+
+	return string(ran_str)
+}
+
+// generateRandomLogs generate `count` logs and inserts them into `db`
+func generateRandomLogs(db *mongo.Client, count int) error {
+	collection := db.Database(mongoStorage.DefaultDB).Collection(mongoStorage.DefaultCollection)
+
+	var (
+		jobID = 1
+		date  = time.Now()
+		logs  []interface{}
+	)
+	for i := 0; i < count; i++ {
+		level := logLevels[rand.Intn(len(logLevels))]
+		data := randomText()
+
+		logs = append(logs, storage.Log{
+			JobID:    uint64(jobID),
+			LogLevel: level,
+			LogData:  data,
+			Date:     date,
+		})
+		if rand.Intn(3) == 0 {
+			jobID += 1
+		}
+		if rand.Intn(2) == 0 {
+			date = date.Add(time.Second)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *flagOperationTimeout)
+	defer cancel()
+	inserted, err := collection.InsertMany(ctx, logs)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%d inserted: %+v \n", len(inserted.InsertedIDs), inserted)
+
+	return nil
+}
+
+func queryLogsEndpoint(query server.Query, retrieveAll bool) (*storage.Result, int, error) {
+	u, err := url.Parse(*flagAdminEndpoint)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var (
+		result           storage.Result
+		statusCode       int
+		currentPage      uint = 0
+		continueRetrieve bool = true
+	)
+
+	if query.Page != nil {
+		currentPage = *query.Page
+	}
+
+	for continueRetrieve {
+		var tmp storage.Result
+
+		q := u.Query()
+		if query.Text != nil {
+			q.Set("text", *query.Text)
+		}
+		if query.StartDate != nil {
+			q.Set("startDate", query.StartDate.Format(storage.DefaultTimestampFormat))
+		}
+		if query.EndDate != nil {
+			q.Set("endDate", query.EndDate.Format(storage.DefaultTimestampFormat))
+		}
+		if query.LogLevel != nil {
+			q.Set("logLevel", *query.LogLevel)
+		}
+		if query.Page != nil {
+			q.Set("page", fmt.Sprint(currentPage))
+		}
+		if query.PageSize != nil {
+			q.Set("pageSize", fmt.Sprint(*query.PageSize))
+		}
+
+		u.RawQuery = q.Encode()
+		res, err := http.Get(u.String())
+		if err != nil {
+			return nil, 0, err
+		}
+		statusCode = res.StatusCode
+
+		err = json.NewDecoder(res.Body).Decode(&tmp)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		result.Logs = append(result.Logs, tmp.Logs...)
+		result.Count = tmp.Count
+
+		currentPage += 1
+		continueRetrieve = retrieveAll && (int64(result.Count)-int64((currentPage)*(*query.PageSize)) > 0)
+		fmt.Print(result.Count, currentPage, query.PageSize)
+	}
+
+	return &result, statusCode, nil
+}
+
+// assertEqualResults checks that the db and api results
+// have the same length and contains the same logdata
+func assertEqualResults(t *testing.T, expected []storage.Log, actual []storage.Log) {
+	// check length
+	if len(expected) != len(actual) {
+		t.Fatal(fmt.Errorf("api and db results dose not have the same length: %d != %d", len(expected), len(actual)))
+		return
+	}
+
+	// it will be used to index the logs by there data
+	// as its randomly generated, so it should be unique
+	table := make(map[string]bool)
+	// populate the tabel
+	for _, log := range expected {
+		table[log.LogData] = true
+	}
+
+	// check equality
+	for _, log := range actual {
+		if _, ok := table[log.LogData]; !ok {
+			t.Fatal(fmt.Errorf("LogData (%s) dose not exist", log.LogData))
+			return
+		}
+	}
+}
+
+func TestLogQuery(t *testing.T) {
+	fmt.Print(*flagMongoEndpoint)
+	db, err := setupCleanDB(*flagMongoEndpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), *flagOperationTimeout)
+	defer cancel()
+	defer db.Disconnect(ctx)
+
+	collection := db.Database(mongoStorage.DefaultDB).Collection(mongoStorage.DefaultCollection)
+
+	err = generateRandomLogs(db, 120)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	/*
+		This range should intersect with logs dates.
+		we started generating logs with time.Now and then added 1s with probability 0.5.
+		Given that for the test the database is local so the insert will not take much,
+		generating more than 4 logs should intersect with this date range
+	*/
+	var (
+		startDate              = time.Now().Add(-2 * time.Second)
+		endDate                = time.Now().Add(1 * time.Second)
+		searchText      string = "a"
+		emptySearchText string = ""
+		page            uint   = 0
+		pageSize        uint   = 20
+		logLevel        string = "info"
+		logLevels       string = "info,debug"
+	)
+
+	cases := []struct {
+		name     string
+		apiQuery server.Query
+		dbQuery  bson.M
+	}{
+		{
+			name: "text-search",
+			apiQuery: server.Query{
+				Text:     &searchText,
+				Page:     &page,
+				PageSize: &pageSize,
+			},
+			dbQuery: bson.M{
+				"logdata": bson.M{"$regex": primitive.Regex{Pattern: "a", Options: "ig"}},
+			},
+		},
+		{
+			name: "logLevel-search",
+			apiQuery: server.Query{
+				Text:     &emptySearchText,
+				LogLevel: &logLevel,
+				Page:     &page,
+				PageSize: &pageSize,
+			},
+			dbQuery: bson.M{
+				"loglevel": "info",
+			},
+		},
+		{
+			name: "multiple-log-levels",
+			apiQuery: server.Query{
+				Text:     &emptySearchText,
+				LogLevel: &logLevels,
+				Page:     &page,
+				PageSize: &pageSize,
+			},
+			dbQuery: bson.M{
+				"loglevel": bson.M{"$in": []string{"info", "debug"}},
+			},
+		},
+		{
+			name: "start-date",
+			apiQuery: server.Query{
+				Text:      &emptySearchText,
+				StartDate: &startDate,
+				Page:      &page,
+				PageSize:  &pageSize,
+			},
+			dbQuery: bson.M{
+				"date": bson.M{
+					"$gte": primitive.NewDateTimeFromTime(startDate),
+				},
+			},
+		},
+		{
+			name: "end-date",
+			apiQuery: server.Query{
+				Text:     &emptySearchText,
+				EndDate:  &endDate,
+				Page:     &page,
+				PageSize: &pageSize,
+			},
+			dbQuery: bson.M{
+				"date": bson.M{
+					"$lte": primitive.NewDateTimeFromTime(endDate),
+				},
+			},
+		},
+		{
+			name: "date-range",
+			apiQuery: server.Query{
+				Text:      &emptySearchText,
+				EndDate:   &endDate,
+				StartDate: &startDate,
+				Page:      &page,
+				PageSize:  &pageSize,
+			},
+			dbQuery: bson.M{
+				"date": bson.M{
+					"$lte": primitive.NewDateTimeFromTime(endDate),
+					"$gte": primitive.NewDateTimeFromTime(startDate),
+				},
+			},
+		},
+		{
+			name: "combined-query",
+			apiQuery: server.Query{
+				Text:      &searchText,
+				StartDate: &startDate,
+				EndDate:   &endDate,
+				LogLevel:  &logLevel,
+				Page:      &page,
+				PageSize:  &pageSize,
+			},
+			dbQuery: bson.M{
+				"logdata": bson.M{"$regex": primitive.Regex{Pattern: "a", Options: "ig"}},
+				"date": bson.M{
+					"$lte": primitive.NewDateTimeFromTime(endDate),
+					"$gte": primitive.NewDateTimeFromTime(startDate),
+				},
+				"loglevel": "info",
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(tt *testing.T) {
+			// get logs from endpoint
+			result, _, err := queryLogsEndpoint(testCase.apiQuery, true)
+			if err != nil {
+				tt.Fatal(err)
+			}
+			// get logs from database
+			var dbLogs []storage.Log
+			ctx, cancel := context.WithTimeout(context.Background(), *flagOperationTimeout)
+			defer cancel()
+			cur, err := collection.Find(ctx, testCase.dbQuery)
+			if err != nil {
+				tt.Fatal(err)
+			}
+
+			ctx, cancel = context.WithTimeout(context.Background(), *flagOperationTimeout)
+			defer cancel()
+			err = cur.All(ctx, &dbLogs)
+			if err != nil {
+				tt.Fatal(err)
+			}
+
+			assertEqualResults(t, dbLogs, result.Logs)
+
+		})
+	}
+
+	t.Run("no-paging", func(t *testing.T) {
+		// get logs from endpoint
+		res, statusCode, err := queryLogsEndpoint(server.Query{
+			Text:     &searchText,
+			PageSize: &pageSize,
+		}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		require.Equal(t, http.StatusOK, statusCode)
+		require.Equal(t, 0, int(res.Page))
+	})
+
+	t.Run("no-filters", func(t *testing.T) {
+		// get logs from endpoint
+		res, statusCode, err := queryLogsEndpoint(server.Query{}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), *flagOperationTimeout)
+		defer cancel()
+		count, err := collection.CountDocuments(ctx, bson.D{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		require.Equal(t, http.StatusOK, statusCode)
+		require.Equal(t, count, int64(res.Count))
+		// the length of the logs should be the maxPageSize (default page size)
+		// as the len(all logs) is 120 and the there is no pageSize in the query
+		require.Equal(t, int(server.MaxPageSize), len(res.Logs))
+	})
+}


### PR DESCRIPTION
- add GET `log` endpoint to query logs
- support text search, date and log level filtering
- add integ test for the log query endpoint

Signed-off-by: Mohamed Abokammer <mahmednabil109@gmail.com>