### PR TITLE
Fix the case when step generates an error which is passed to a step state, but test runner exits first

### DIFF
--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -271,7 +271,7 @@ func (tr *TestRunner) waitSteps(ctx xcontext.Context) ([]json.RawMessage, error)
 			resumeStates = append(resumeStates, ss.GetInitResumeState())
 			continue
 		}
-		result, err := ss.stepRunner.WaitResults(shutdownCtx)
+		result, err := ss.WaitResults(shutdownCtx)
 		if err != nil {
 			stepsNeverReturned = append(stepsNeverReturned, ss.GetTestStepLabel())
 			ss.SetError(ctx, &cerrors.ErrTestStepsNeverReturned{StepNames: []string{ss.GetTestStepLabel()}})


### PR DESCRIPTION
The test logs are:

time="2022-08-07T18:51:48Z" level=debug msg="monitor: active" file="test_runner.go:447"
time="2022-08-07T18:51:48Z" level=debug msg="monitor: starting at step [#0 Step1]" file="test_runner.go:449"
time="2022-08-07T18:51:48Z" level=debug msg="monitor pass 1: current step [#0 Step1]" file="test_runner.go:462"
time="2022-08-07T18:51:48Z" level=debug msg="monitor pass 1: [#0 Step1]: [Target{ID: \"TExtra\"} 0 init false <nil>]" file="test_runner.go:466"
time="2022-08-07T18:51:48Z" level=debug msg="monitor pass 1: [#0 Step1]: not all targets injected yet ([Target{ID: \"TExtra\"} 0 init false <nil>])" file="test_runner.go:471"
time="2022-08-07T18:51:48Z" level=debug msg="[Target{ID: \"TExtra\"} 0 init false <nil>]: target handler active" file="test_runner.go:326" target=TExtra
time="2022-08-07T18:51:48Z" level=debug msg="[Target{ID: \"TExtra\"} 0 begin false <nil>]: injecting into [#0 Step1]" file="test_runner.go:365" target=TExtra
time="2022-08-07T18:51:48Z" level=info msg="Obtained '{Target{ID: \"TExtra\"} <nil>}' for target 'TExtra'" file="step_runner.go:329" step_index=0 step_label=Step1 target=TExtra
time="2022-08-07T18:51:48Z" level=info msg="Obtained '{Target{ID: \"TExtra2\"} <nil>}' for target 'TExtra2'" file="step_runner.go:329" step_index=0 step_label=Step1 target=TExtra
time="2022-08-07T18:51:48Z" level=error msg="err: test step Step1 returned unexpected result for TExtra2" file="step_runner.go:436" step_index=0 step_label=Step1 target=TExtra
time="2022-08-07T18:51:48Z" level=debug msg="Reading loop finished" file="step_runner.go:143" step_index=0 step_label=Step1 target=TExtra
time="2022-08-07T18:51:48Z" level=debug msg="Got target result: '<nil>'" file="test_runner.go:382" target=TExtra
time="2022-08-07T18:51:48Z" level=debug msg="[Target{ID: \"TExtra\"} 0 end true <nil>]: target handler finished" file="test_runner.go:322" target=TExtra
time="2022-08-07T18:51:48Z" level=debug msg="monitor pass 2: current step [#0 Step1]" file="test_runner.go:462"
time="2022-08-07T18:51:48Z" level=debug msg="monitor pass 2: [#0 Step1]: [Target{ID: \"TExtra\"} 0 end true <nil>]" file="test_runner.go:466"
time="2022-08-07T18:51:48Z" level=debug msg="monitor pass 2: [#0 Step1]: no more targets, closing input channel" file="test_runner.go:485"
time="2022-08-07T18:51:48Z" level=debug msg="monitor pass 0: [Target{ID: \"TExtra\"} 0 end true <nil>]" file="test_runner.go:509"
time="2022-08-07T18:51:48Z" level=debug msg="monitor: finished, <nil>" file="test_runner.go:525"
time="2022-08-07T18:51:48Z" level=debug msg="waiting for step runners to finish" file="test_runner.go:283"
time="2022-08-07T18:51:48Z" level=debug msg="cancel target handlers" file="test_runner.go:203"
time="2022-08-07T18:51:48Z" level=debug msg="leaving, err test step Step1 returned unexpected result for TExtra2, target states:" file="test_runner.go:214"
time="2022-08-07T18:51:48Z" level=debug msg="  0 target: '[Target{ID: \"TExtra\"} 0 end true <nil>]' step err: '<nil>', resume ok: 'false'" file="test_runner.go:236"
time="2022-08-07T18:51:48Z" level=debug msg="- 0 in flight, ok to resume? false" file="test_runner.go:238"
time="2022-08-07T18:51:48Z" level=debug msg="step states:" file="test_runner.go:239"
time="2022-08-07T18:51:48Z" level=debug msg="  0 [#0 Step1] true %!t(<nil>) " file="test_runner.go:241"
--- FAIL: TestTestRunnerSuite (2.43s)
    --- FAIL: TestTestRunnerSuite/TestStepYieldsResultForNonexistentTarget (0.01s)
        test_runner_test.go:373: 
            	Error Trace:	/go/src/github.com/linuxboot/contest/pkg/runner/test_runner_test.go:373
            	Error:      	Not equal: 
            	            	expected: "\n{[1 1 SimpleTest 0 Step1][(*Target)(nil) TestError &\"\\\"test step Step1 returned unexpected result for TExtra2\\\"\"]}\n"
            	            	actual  : "\n\n"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,3 +1,3 @@
            	            	 
            	            	-{[1 1 SimpleTest 0 Step1][(*Target)(nil) TestError &"\"test step Step1 returned unexpected result for TExtra2\""]}
            	            	 
            	            	+
            	Test:       	TestTestRunnerSuite/TestStepYieldsResultForNonexistentTarget
time="2022-08-07T18:51:48Z" level=debug msg="TestStep finished '<nil>', rs: ''" file="step_runner.go:417" step_index=0 step_label=Step1 target=TExtra
time="2022-08-07T18:51:48Z" level=debug msg="output channel closed" file="step_runner.go:397" step_index=0 step_label=Step1 target=TExtra
time="2022-08-07T18:51:48Z" level=debug msg="Running loop finished" file="step_runner.go:137" step_index=0 step_label=Step1 target=TExtra
time="2022-08-07T18:51:48Z" level=debug msg="StepRunner finished" file="step_runner.go:129" step_index=0 step_label=Step1 target=TExtra