### PR TITLE
Always wait for StepRunner to finish in WaitResults method even in case of a failure

### DIFF
--- a/pkg/runner/step_runner.go
+++ b/pkg/runner/step_runner.go
@@ -237,20 +237,6 @@ func (sr *StepRunner) Started() bool {
 // WaitResults returns TestStep.Run() output
 // It returns an error if and only if waiting was terminated by inputQueue ctx argument and returns ctx.Err()
 func (sr *StepRunner) WaitResults(ctx context.Context) (stepResult StepResult, err error) {
-	sr.mu.Lock()
-	resultErr := sr.resultErr
-	resultResumeState := sr.resultResumeState
-	sr.mu.Unlock()
-
-	// StepRunner either finished with error or behaved incorrectly
-	// it makes no sense to wait while it finishes, return what we have
-	if resultErr != nil {
-		return StepResult{
-			Err:         resultErr,
-			ResumeState: resultResumeState,
-		}, nil
-	}
-
 	select {
 	case <-ctx.Done():
 		// give priority to returning results


### PR DESCRIPTION
The reason was the following test failure:

time="2022-08-09T15:09:51Z" level=debug msg="monitor: active" file="test_runner.go:447"
time="2022-08-09T15:09:51Z" level=debug msg="monitor: starting at step [#0 Step1]" file="test_runner.go:449"
time="2022-08-09T15:09:51Z" level=debug msg="monitor pass 1: current step [#0 Step1]" file="test_runner.go:462"
time="2022-08-09T15:09:51Z" level=debug msg="monitor pass 1: [#0 Step1]: [Target{ID: \"T1\"} 0 init false <nil>]" file="test_runner.go:466"
time="2022-08-09T15:09:51Z" level=debug msg="monitor pass 1: [#0 Step1]: not all targets injected yet ([Target{ID: \"T1\"} 0 init false <nil>])" file="test_runner.go:471"
time="2022-08-09T15:09:51Z" level=debug msg="[Target{ID: \"T1\"} 0 init false <nil>]: target handler active" file="test_runner.go:326" target=T1
time="2022-08-09T15:09:51Z" level=debug msg="[Target{ID: \"T1\"} 0 begin false <nil>]: injecting into [#0 Step1]" file="test_runner.go:365" target=T1
time="2022-08-09T15:09:51Z" level=debug msg="monitor pass 2: current step [#0 Step1]" file="test_runner.go:462"
time="2022-08-09T15:09:51Z" level=debug msg="monitor pass 2: [#0 Step1]: [Target{ID: \"T1\"} 0 run false <nil>]" file="test_runner.go:466"
time="2022-08-09T15:09:51Z" level=debug msg="monitor pass 2: [#0 Step1]: no more targets, closing input channel" file="test_runner.go:485"
time="2022-08-09T15:09:51Z" level=debug msg="monitor pass 0: [Target{ID: \"T1\"} 0 run false <nil>]" file="test_runner.go:509"
time="2022-08-09T15:09:51Z" level=debug msg="TestStep finished '<nil>', rs: ''" file="step_runner.go:417" step_index=0 step_label=Step1 target=T1
time="2022-08-09T15:09:51Z" level=error msg="err: test step Step1 closed output channels (api violation)" file="step_runner.go:436" step_index=0 step_label=Step1 target=T1
time="2022-08-09T15:09:51Z" level=debug msg="output channel closed" file="step_runner.go:397" step_index=0 step_label=Step1 target=T1
time="2022-08-09T15:09:51Z" level=debug msg="Running loop finished" file="step_runner.go:137" step_index=0 step_label=Step1 target=T1
time="2022-08-09T15:09:51Z" level=error msg="Step 'Step1' failed with error: test step Step1 closed output channels (api violation)" file="step_state.go:184" step_index=0 step_label=Step1 target=T1
time="2022-08-09T15:09:51Z" level=debug msg="StepRunner fully stopped" file="step_state.go:136" step_index=0 step_label=Step1 target=T1
time="2022-08-09T15:09:51Z" level=debug msg="step runner stopped: 'test step Step1 closed output channels (api violation)'" file="test_runner.go:393" target=T1
time="2022-08-09T15:09:51Z" level=error msg="Target handler failed: test step Step1 closed output channels (api violation)" file="test_runner.go:400" target=T1
time="2022-08-09T15:09:51Z" level=debug msg="[Target{ID: \"T1\"} 0 run true <nil>]: target handler finished" file="test_runner.go:322" target=T1
time="2022-08-09T15:09:51Z" level=debug msg="monitor: finished, test step Step1 closed output channels (api violation)" file="test_runner.go:525"
time="2022-08-09T15:09:51Z" level=error msg="monitor returned error: \"test step Step1 closed output channels (api violation)\", canceling" file="test_runner.go:190"
time="2022-08-09T15:09:51Z" level=debug msg="waiting for step runners to finish" file="test_runner.go:283"
time="2022-08-09T15:09:51Z" level=debug msg="cancel target handlers" file="test_runner.go:203"
time="2022-08-09T15:09:51Z" level=debug msg="leaving, err test step Step1 closed output channels (api violation), target states:" file="test_runner.go:214"
time="2022-08-09T15:09:51Z" level=debug msg="  0 target: '[Target{ID: \"T1\"} 0 run true <nil>]' step err: 'test step Step1 closed output channels (api violation)', resume ok: 'false'" file="test_runner.go:236"
time="2022-08-09T15:09:51Z" level=debug msg="- 1 in flight, ok to resume? false" file="test_runner.go:238"
time="2022-08-09T15:09:51Z" level=debug msg="step states:" file="test_runner.go:239"
time="2022-08-09T15:09:51Z" level=debug msg="  0 [#0 Step1] true &{%!t(string=Step1)} " file="test_runner.go:241"
--- FAIL: TestTestRunnerSuite (2.25s)
    --- FAIL: TestTestRunnerSuite/TestStepClosesChannels (0.01s)
        test_runner_test.go:349: 
            	Error Trace:	/go/src/github.com/linuxboot/contest/pkg/runner/test_runner_test.go:349
            	Error:      	Not equal: 
            	            	expected: "\n{[1 1 SimpleTest 0 Step1][Target{ID: \"T1\"} TargetIn]}\n{[1 1 SimpleTest 0 Step1][Target{ID: \"T1\"} TargetOut]}\n"
            	            	actual  : "\n{[1 1 SimpleTest 0 Step1][Target{ID: \"T1\"} TargetIn]}\n"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -2,3 +2,2 @@
            	            	 {[1 1 SimpleTest 0 Step1][Target{ID: "T1"} TargetIn]}
            	            	-{[1 1 SimpleTest 0 Step1][Target{ID: "T1"} TargetOut]}
            	            	 
            	Test:       	TestTestRunnerSuite/TestStepClosesChannels
FAIL
FAIL	github.com/linuxboot/contest/pkg/runner	22.364s
FAIL
Error: Process completed with exit code 1.
0s

After thinking for a while it seems that StepRunner.outputLoop just reads the targetResult and "control flow" switches to another goroutine.