### PR TITLE
Add tag endpoint to admin server

### DIFF
--- a/cmds/admin_server/job/rdb/rdb.go
+++ b/cmds/admin_server/job/rdb/rdb.go
@@ -1,0 +1,139 @@
+package rdb
+
+import (
+	"fmt"
+
+	"github.com/google/go-safeweb/safesql"
+	adminServerJob "github.com/linuxboot/contest/cmds/admin_server/job"
+	"github.com/linuxboot/contest/pkg/xcontext"
+)
+
+var (
+	tagsStmt = safesql.New(`SELECT tag, COUNT(tag) FROM job_tags WHERE tag REGEXP CONCAT('.*',?,'.*') GROUP BY tag`)
+	jobStmt  = safesql.New(`SELECT t.job_id, r.reporter_name, r.report_time, r.data FROM job_tags t LEFT JOIN final_reports r ON t.job_id = r.job_id WHERE t.tag = ?`)
+)
+
+// SQL defines a struct that wraps a db connection to job sql database
+type Storage struct {
+	db *safesql.DB
+}
+
+func New(dbURI, driveName string) (*Storage, error) {
+
+	if driveName == "" {
+		driveName = "mysql"
+	}
+
+	db, err := safesql.Open(driveName, dbURI)
+	if err != nil {
+		return nil, fmt.Errorf("error while initializing the db: %w", err)
+	}
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("error while connecting to the db: %w", err)
+	}
+
+	return &Storage{
+		db: &db,
+	}, nil
+}
+
+// GetTags returns tags that has a tag matches tagPattern
+func (r *Storage) GetTags(ctx xcontext.Context, tagPattern string) ([]adminServerJob.Tag, error) {
+	var resultErr error
+	res := []adminServerJob.Tag{}
+	doneChan := make(chan struct{})
+
+	go func(doneChan chan<- struct{}) {
+		defer func() {
+			doneChan <- struct{}{}
+		}()
+
+		rows, err := r.db.Query(tagsStmt, tagPattern)
+		if err != nil {
+			resultErr = fmt.Errorf("error while listing projects with tag like %s (sql: %q): %w", tagPattern, tagsStmt, err)
+			return
+		}
+		defer func() {
+			err = rows.Close()
+			if err != nil {
+				ctx.Errorf("error while closing the rows reader: %w", err)
+			}
+		}()
+
+		for rows.Next() {
+			if rows.Err() != nil {
+				resultErr = fmt.Errorf("error while reading the rows from query result: %w", err)
+				return
+			}
+
+			var tag adminServerJob.Tag
+			if err := rows.Scan(&tag.Name, &tag.JobsCount); err != nil {
+				resultErr = fmt.Errorf("error while scaning query result (sql: %q): %w", tagsStmt, err)
+				return
+			}
+			res = append(res, tag)
+		}
+	}(doneChan)
+
+	for {
+		select {
+		case <-doneChan:
+			return res, resultErr
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+// GetJobs returns jobs with final report if exists that are under a given tagName
+func (r *Storage) GetJobs(ctx xcontext.Context, tagName string) ([]adminServerJob.Job, error) {
+	var resultErr error
+	res := []adminServerJob.Job{}
+	doneChan := make(chan struct{})
+
+	go func(doneChan chan<- struct{}) {
+		defer func() {
+			doneChan <- struct{}{}
+		}()
+
+		rows, err := r.db.Query(jobStmt, tagName)
+		if err != nil {
+			resultErr = fmt.Errorf("error while listing jobs with tag %s (sql: %q): %w", tagName, jobStmt, err)
+			return
+		}
+		defer func() {
+			err = rows.Close()
+			if err != nil {
+				ctx.Errorf("error while closing the rows reader: %w", err)
+			}
+		}()
+
+		for rows.Next() {
+			if rows.Err() != nil {
+				resultErr = fmt.Errorf("error while reading the rows from query result: %w", err)
+				return
+			}
+
+			var job adminServerJob.Job
+			if err := rows.Scan(&job.JobID, &job.ReporterName, &job.ReportTime, &job.Data); err != nil {
+				resultErr = fmt.Errorf("error while scaning the job (sql: %q): %w", jobStmt, err)
+				return
+			}
+			res = append(res, job)
+		}
+	}(doneChan)
+
+	for {
+		select {
+		case <-doneChan:
+			return res, resultErr
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func (r *Storage) Close() error {
+	return r.db.Close()
+}

--- a/cmds/admin_server/job/storage.go
+++ b/cmds/admin_server/job/storage.go
@@ -1,0 +1,31 @@
+package job
+
+import (
+	"time"
+
+	"github.com/linuxboot/contest/pkg/types"
+	"github.com/linuxboot/contest/pkg/xcontext"
+)
+
+// DB wraps a job database
+type Storage interface {
+	GetTags(ctx xcontext.Context, tagPattern string) ([]Tag, error)
+	GetJobs(ctx xcontext.Context, projectName string) ([]Job, error)
+}
+
+// Tag contains metadata about jobs under a given tag
+type Tag struct {
+	Name string
+	// number of jobs with under this tag
+	JobsCount uint
+}
+
+// Job contains final report data about that job_id
+type Job struct {
+	JobID types.JobID
+	// fields for the final report of the job if it exists.
+	ReporterName *string
+	ReportTime   *time.Time
+	Success      *bool
+	Data         *string
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
             # using the same dockerfile as it copies the whole context repo
             # then we run admin_server from the cmds
             dockerfile: docker/contest/Dockerfile
-        command: bash -c "cd /go/src/github.com/linuxboot/contest/cmds/admin_server/ && go run . -port 8000 -dbURI 'mongodb://mongostorage:27017'"
+        command: bash -c "cd /go/src/github.com/linuxboot/contest/cmds/admin_server/ && go run . -port 8000 -dbURI 'mongodb://mongostorage:27017' -contestdbURI 'contest:contest@tcp(dbstorage:3306)/contest_integ?parseTime=true'"
         ports:
             - 8000:8000
         healthcheck:
@@ -48,6 +48,8 @@ services:
             timeout: 1s
             retries: 5
         depends_on:
+            mysql:
+                condition: service_healthy
             mongo:
                 condition: service_healthy
         networks:

--- a/tests/integ/admin_server/flags_test.go
+++ b/tests/integ/admin_server/flags_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 var (
-	flagAdminEndpoint    = flag.String("adminServer", "http://adminserver:8000/log", "admin server log push endpoint")
-	flagMongoEndpoint    = flag.String("mongoDBURI", "mongodb://mongostorage:27017", "mongodb URI")
-	flagOperationTimeout = flag.Duration("operationTimeout", time.Duration(10*time.Second), "operation timeout duration")
+	flagAdminEndpoint        = flag.String("adminServer", "http://adminserver:8000/log", "admin server log push endpoint")
+	flagAdminProjectEndpoint = flag.String("ProjectEndpoint", "http://adminserver:8000/tag", "admin server project query endpoint")
+	flagMongoEndpoint        = flag.String("mongoDBURI", "mongodb://mongostorage:27017", "mongodb URI")
+	flagContestDBURI         = flag.String("ContestDBURI", "contest:contest@tcp(dbstorage:3306)/contest_integ?parseTime=true", "contest db URI")
+	flagOperationTimeout     = flag.Duration("operationTimeout", time.Duration(10*time.Second), "operation timeout duration")
 )

--- a/tests/integ/admin_server/group_jobs_by_project_test.go
+++ b/tests/integ/admin_server/group_jobs_by_project_test.go
@@ -1,0 +1,232 @@
+//go:build integration
+// +build integration
+
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/google/go-safeweb/safesql"
+	"github.com/linuxboot/contest/cmds/admin_server/server"
+	"github.com/linuxboot/contest/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	insertJobStmt    = "insert into jobs (name, descriptor, extended_descriptor, requestor, server_id, request_time) values (?, ?, ?, ?, ?, ?)"
+	insertJobTagStmt = "insert into job_tags (job_id, tag) values (?, ?)"
+)
+
+func InitCleanDBConn(uri string) (*safesql.DB, error) {
+	db, err := safesql.Open("mysql", uri)
+	if err != nil {
+		return nil, fmt.Errorf("error while opening db conn: %w", err)
+	}
+
+	if _, err := db.Exec(safesql.New("TRUNCATE TABLE job_tags")); err != nil {
+		return nil, fmt.Errorf("error while cleaning table job_tags: %w", err)
+	}
+
+	if _, err := db.Exec(safesql.New("TRUNCATE TABLE jobs")); err != nil {
+		return nil, fmt.Errorf("error while cleaning table jobs: %w", err)
+	}
+	return &db, nil
+}
+
+func AddJobsWithTags(db *safesql.DB, jobNames []string, tags []string) ([]types.JobID, error) {
+	var ids []types.JobID
+	for i, name := range jobNames {
+		res, err := db.Exec(
+			safesql.New(insertJobStmt),
+			name,
+			fmt.Sprintf("descriptor placeholder %d", i),
+			fmt.Sprintf("extend descriptor placeholder %d", i),
+			fmt.Sprintf("requestor %d", i),
+			fmt.Sprintf("server id %d", i),
+			time.Now(),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("error while inserting tmp jobs for testing: %w", err)
+		}
+		id, err := res.LastInsertId()
+		if err != nil {
+			return nil, fmt.Errorf("error while getting the last inserted id: %w", err)
+		}
+		ids = append(ids, types.JobID(id))
+	}
+
+	for _, tag := range tags {
+		for _, id := range ids {
+			if _, err := db.Exec(safesql.New(insertJobTagStmt), id, tag); err != nil {
+				return nil, fmt.Errorf("error while inserting job tag: %w", err)
+			}
+		}
+	}
+
+	return ids, nil
+}
+
+func getJobs(addr, searchTag string) ([]types.JobID, int, error) {
+	url, err := url.ParseRequestURI(addr)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error while parsing the url(%v): %w", addr, err)
+	}
+	url.Path = path.Join(url.Path, fmt.Sprint(searchTag), "jobs")
+
+	res, err := http.Get(url.String())
+	if err != nil {
+		return nil, 0, fmt.Errorf("error while Sending GET request: %w", err)
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, res.StatusCode, nil
+	}
+
+	var jobs []server.Job
+	err = json.NewDecoder(res.Body).Decode(&jobs)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error while parsing request body: %w", err)
+	}
+
+	var jobIDs []types.JobID
+	for _, job := range jobs {
+		jobIDs = append(jobIDs, job.JobID)
+	}
+	return jobIDs, res.StatusCode, nil
+}
+
+func getTags(addr, searchTag string) ([]server.Tag, int, error) {
+	url, err := url.Parse(addr)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error while parsing the url(%v): %w", addr, err)
+	}
+
+	q := url.Query()
+	q.Set("text", searchTag)
+	url.RawQuery = q.Encode()
+
+	res, err := http.Get(url.String())
+	if err != nil {
+		return nil, 0, fmt.Errorf("error while Sending GET request: %w", err)
+	}
+	if res.StatusCode != http.StatusOK {
+		return nil, res.StatusCode, nil
+	}
+
+	var projects []server.Tag
+	err = json.NewDecoder(res.Body).Decode(&projects)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error while parsing request body: %w", err)
+	}
+
+	return projects, res.StatusCode, nil
+}
+
+func TestGetJobs(t *testing.T) {
+	testCases := []struct {
+		testName  string
+		names     []string
+		tags      []string
+		searchTag string
+	}{
+		{
+			testName:  "base-case",
+			names:     []string{"job1", "job2", "job3"},
+			tags:      []string{"tag1"},
+			searchTag: "tag1",
+		},
+		{
+			testName:  "not-existing-tag",
+			names:     []string{},
+			tags:      []string{},
+			searchTag: "AnyThing",
+		},
+	}
+
+	db, err := InitCleanDBConn(*flagContestDBURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(tt *testing.T) {
+			jobIDs, err := AddJobsWithTags(db, testCase.names, testCase.tags)
+			if err != nil {
+				tt.Fatal(err)
+			}
+
+			serverJobIDs, statusCode, err := getJobs(*flagAdminProjectEndpoint, testCase.searchTag)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			require.Equal(t, statusCode, http.StatusOK)
+			require.Equal(t, len(jobIDs), len(serverJobIDs))
+			require.Equal(t, jobIDs, serverJobIDs)
+		})
+	}
+
+	t.Run("bad-request", func(tt *testing.T) {
+		_, statusCode, err := getJobs(*flagAdminProjectEndpoint, "*_?tag")
+		if err != nil {
+			tt.Fatal(err)
+		}
+		require.Equal(t, http.StatusBadRequest, statusCode)
+	})
+}
+
+func TestGetTags(t *testing.T) {
+	testCases := []struct {
+		testName  string
+		names     []string
+		tags      []string
+		searchTag string
+		expected  []server.Tag
+	}{
+		{
+			testName:  "base-case",
+			names:     []string{"job1", "job2", "job3"},
+			tags:      []string{"tag1", "tag2", "not1"},
+			searchTag: "ta",
+			expected: []server.Tag{
+				{Name: "tag1", JobsCount: 3},
+				{Name: "tag2", JobsCount: 3},
+			},
+		},
+		{
+			testName:  "not-existing-tag",
+			names:     []string{},
+			searchTag: "AnyThing",
+			expected:  []server.Tag{},
+		},
+	}
+
+	db, err := InitCleanDBConn(*flagContestDBURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(tt *testing.T) {
+			_, err := AddJobsWithTags(db, testCase.names, testCase.tags)
+			if err != nil {
+				tt.Fatal(err)
+			}
+
+			serverProjects, statusCode, err := getTags(*flagAdminProjectEndpoint, testCase.searchTag)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			require.Equal(t, statusCode, http.StatusOK)
+			require.Equal(t, len(testCase.expected), len(serverProjects))
+			require.Equal(t, testCase.expected, serverProjects)
+		})
+	}
+}


### PR DESCRIPTION
The project is just a bunch of contest jobs for a specific purpose (like testing a specific platform). Here I implement the api to fetch jobs and search them by project name using tags.

- add tag & job endpoints to query tasks by tag/project name

Signed-off-by: Mohamed Abokammer <mahmednabil109@gmail.com>