### PR TITLE
fix(logging): Do not report 'logger.go' as the logging file

### DIFF
--- a/pkg/logging/default_options.go
+++ b/pkg/logging/default_options.go
@@ -7,10 +7,14 @@ package logging
 
 import (
 	"context"
+	stdruntime "runtime"
+	"strings"
 
+	"github.com/facebookincubator/go-belt/pkg/runtime"
 	"github.com/facebookincubator/go-belt/tool/logger"
 	"github.com/facebookincubator/go-belt/tool/logger/implementation/logrus"
 	"github.com/facebookincubator/go-belt/tool/logger/implementation/logrus/formatter"
+	loggertypes "github.com/facebookincubator/go-belt/tool/logger/types"
 )
 
 // DefaultOptions is a set options recommended to use by default.
@@ -22,6 +26,23 @@ func WithBelt(
 	l.Formatter = &formatter.CompactText{
 		TimestampFormat: "2006-01-02T15:04:05.000Z07:00",
 	}
-	ctx = logger.CtxWithLogger(ctx, logrus.New(l).WithLevel(logLevel))
+	ctx = logger.CtxWithLogger(ctx, logrus.New(l, loggertypes.OptionGetCallerFunc(getCallerPC)).WithLevel(logLevel))
 	return ctx
+}
+
+func getCallerPC() runtime.PC {
+	return runtime.Caller(func(pc uintptr) bool {
+		if !runtime.DefaultCallerPCFilter(pc) {
+			return false
+		}
+
+		fn := stdruntime.FuncForPC(pc)
+		funcName := fn.Name()
+		switch {
+		case strings.Contains(funcName, "pkg/logging"):
+			return false
+		}
+
+		return true
+	})
 }


### PR DESCRIPTION
Without this fix:

    [2023-06-07T15:19:31.783+01:00 I logger.go:53] Registering test step sshcmd
    [2023-06-07T15:19:31.783+01:00 I logger.go:53] Registering reporter noop

With this fix:

    [2023-06-07T15:12:38.611+01:00 I pluginregistry.go:91] Registering test step sshcmd
    [2023-06-07T15:12:38.611+01:00 I pluginregistry.go:115] Registering reporter noop